### PR TITLE
Lift ImageTileSource out of ContactMatrixView (#428)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,78 @@
+# Context — juicebox.js
+
+The ubiquitous language of this codebase. When naming a module, a test, an issue
+or a variable, use the term as defined here rather than a synonym.
+
+juicebox.js is an **embeddable component**, not a standalone app. It renders Hi-C
+contact maps and is embedded in host apps such as juicebox-web and Spacewalk. The
+dev server and dashboard exist so developers can see the library in action
+without a host app.
+
+## Core concepts
+
+**Contact map** — the 2D matrix of interaction frequencies between genomic loci.
+The thing the user is looking at. A browser instance shows one primary contact
+map and optionally a **control map** for comparison.
+
+**Canonical state** — the seven fields on `State` (`js/hicState.js`) that fully
+and unambiguously specify the view: `chr1`, `chr2`, `x`, `y`, `zoom`,
+`pixelSize`, `normalization`. Everything else the user sees is derived from
+these. See `docs/state-manipulation.md`.
+
+**Projection** — anything derived from canonical state on read rather than
+stored. The **locus** is the important one: chromosome BP coordinates computed
+via `state.getLocus(dataset, viewDimensions)`, never stored, because view
+dimensions can change without any state mutation.
+
+**Chokepoint** — `state.setView`, the single method through which all canonical
+state mutations flow. No code outside `js/hicState.js` mutates state fields
+directly.
+
+**Translator** — a thin method on `State` converting domain-specific input
+(screen pixel deltas, BP loci, a peer browser's state) into canonical arguments
+for the chokepoint. `panShift`, `updateWithLoci`, `setWithZoom` and friends.
+
+**Bulk replacement** — the deliberate exception to the chokepoint: session and
+URL restore replace the whole `State` object rather than mutating it, because at
+restore time there is nothing to translate relative to.
+
+## Rendering
+
+**Image tile** — a square raster of the contact map at a given zoom, row and
+column (`imageTileDimension`, currently 685 bins square). Cached, keyed by
+chromosome pair, bin size, unit, grid position, normalization and display mode.
+Notably *not* keyed by pan position or pixel size — those affect where a tile is
+painted, not what it contains.
+
+**Track tile** — an unrelated concept despite the shared word: a buffered span of
+1D track features for one axis (`js/tile.js`). Has nothing to do with image
+tiles. When either could be meant, say which.
+
+**Display mode** — which map or combination is rendered: `A` (primary), `B`
+(control), `AOB` (A over B, ratio), `BOA` (B over A, ratio), `AMB` (A minus B,
+difference). The combining modes require matching resolutions on both maps, so
+the primary map's zoom index is translated to the control map's equivalent.
+
+**Zoom data** — a resolution-specific view of a matrix, carrying bin size, unit
+and per-map average counts. Obtained from a matrix by zoom index.
+
+**Bin** — the unit of resolution. Canonical `x`/`y` are bin positions, not base
+pairs; `pixelSize` is pixels per bin.
+
+**Live contact map** — a streaming map sourced from hic-straw rather than a
+static `.hic` file, driven by Spacewalk. Emits ensemble contact *frequencies*
+bounded in (0, 1] rather than raw counts, which is why the auto colour-scale
+heuristics branch on `isLive`. Static `.hic` visualization remains the primary
+focus of this library.
+
+**Track pair** — one 1D track rendered on both axes, as a pair of renderers
+sharing a track (`js/trackPair.js`).
+
+## Architecture vocabulary
+
+Refactoring work in this repo uses the deep-module vocabulary: **module**,
+**interface**, **implementation**, **depth**, **seam**, **adapter**,
+**leverage**, **locality**. Prefer **seam** over "boundary" and **interface**
+over "API". A module is **deep** when a lot of behaviour sits behind a small
+interface, **shallow** when the interface is nearly as complex as the
+implementation.

--- a/dev/big_viewport.html
+++ b/dev/big_viewport.html
@@ -48,25 +48,33 @@
 
     import juicebox from '../js/index.js';
 
+    // NOTE ON HOSTS -- do not repoint this harness at encodeproject.org or
+    // hicfiles.s3.amazonaws.com. Both gate on User-Agent, and User-Agent is a
+    // forbidden header name in the Fetch spec, so the browser silently drops
+    // the "IGV" value hic-straw sets. Those hosts therefore serve 405 / 403 to
+    // any browser, while curl and Node succeed -- which makes the failure look
+    // like a juicebox bug. It is not. Symptom is a bare Error thrown from
+    // hic-straw's readHeaderAndFooter, with no message because statusText is
+    // always empty on HTTP/2.
+    //
+    // Verified reachable from a browser: this wasabisys bucket, and
+    // raw.githubusercontent.com/igvteam/igv-data.
+
     const config = {
         "width": 1000,
         "height": 1000,
-        "url": "https://www.encodeproject.org/files/ENCFF799QGA/@@download/ENCFF799QGA.hic",
-        // "name": "in-situ agar GM12878 MboI experiment",
-        "tracks": [
-            {
-                "url": "https://www.dropbox.com/s/gvfvcvt146rtm5b/GSE63525_GM12878_subcompartments.bed?dl=0",
-                "name": "RH2014"
-            },
-            {
-                "url": "https://www.encodeproject.org/files/ENCFF906RJB/@@download/ENCFF906RJB.bigWig",
-                "name": "GM12878 H3K36me3 ",
-                "min": 0,
-                "max": 3.8794891834259033,
-                "color": "#018448"
-            }
-        ]
+        "url": "https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/GM12878/diploid/r.hic",
+        "name": "GM12878 diploid (r)",
+        "nvi": "43762184328,25419"
     }
+
+    // The previous 1D tracks are gone rather than repointed. The GSE63525
+    // subcompartments BED is hg19 and this map is GRCh38, so keeping it would
+    // have placed features at wrong coordinates -- worse than no track. The
+    // ENCODE bigWig alongside it is unreachable from a browser for the
+    // User-Agent reason above. This harness exercises viewport size and the
+    // image tile grid; the sibling harnesses on this same map carry no 1D
+    // tracks either.
 
     const container = document.getElementById("app-container");
 

--- a/dev/generic-test-harness.html
+++ b/dev/generic-test-harness.html
@@ -62,6 +62,31 @@
             ]
         };
 
+    // A/B compare gate. The diploid pair from the same bucket -- both reachable,
+    // both hg38, and verified to carry identical resolution lists, so the zoom
+    // index translation between primary and control is the identity and AOB/BOA
+    // cannot throw at any zoom.
+    //
+    // This exercises the wiring: control dataset selection, the second
+    // getContactRecords call, and ratio scoring. It does NOT exercise the
+    // interesting branch of the translation, where the two maps carry different
+    // resolutions -- that path is covered by unit tests in
+    // test/testImageTileCore.js, and no verified-reachable mismatched pair is
+    // known.
+    //
+    // Switch displayMode to 'BOA' to check the swapped-role path. 'AMB' throws:
+    // diffColorScale has been unimplemented since 2018, see issue #426.
+    const config_ab_compare =
+        {
+            "url": "https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/GM12878/diploid/r.hic",
+            "name": "r.hic",
+            "nvi": "43762184328,25419",
+            "controlUrl": "https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/GM12878/diploid/a.hic",
+            "controlName": "a.hic",
+            "controlNvi": "43835341324,25419",
+            "displayMode": "AOB"
+        };
+
     const config_erez_bug =
         {
             "browsers": [
@@ -269,6 +294,11 @@
             "selectedGene": "egfr"
         };
 
+    // Two configs in this file currently load. Swap the second argument:
+    //   config_smoke      -- one map plus a 2D annotation track
+    //   config_ab_compare -- A/B ratio compare (AOB), the only working A/B gate
+    // Everything else here points at hosts that reject browsers; see the note
+    // at the top of this script.
     juicebox.init(document.getElementById("app-container"), config_smoke)
         .then(browser => {
 

--- a/dev/generic-test-harness.html
+++ b/dev/generic-test-harness.html
@@ -23,6 +23,45 @@
     import juicebox from '../js/index.js';
     // import juicebox from "https://cdn.jsdelivr.net/gh/igvteam/juicebox.js@juicebox-llm-project/dist/juicebox.esm.js";
 
+    // ------------------------------------------------------------------
+    // FIXTURE ROT -- read before picking a config below.
+    //
+    // All seven of the historical configs in this file are unreachable from a
+    // browser. They point at encodeproject.org (405) or the hicfiles /
+    // s3.amazonaws.com/hicfiles / dnazoo buckets (403). Both gate on
+    // User-Agent, and User-Agent is a forbidden header name in the Fetch spec,
+    // so hic-straw's headers['User-Agent'] = 'IGV' is silently dropped by the
+    // browser. curl and Node succeed; the browser cannot. See aidenlab/
+    // hic-straw#46. The symptom is a bare Error from readHeaderAndFooter with
+    // no message, because statusText is empty on HTTP/2 (hic-straw#47).
+    //
+    // The configs are left in place -- they document real scenarios and become
+    // usable again if the fixtures are rehosted. Verified reachable today:
+    // the wasabisys buckets, dropbox, hgdownload.soe.ucsc.edu, and the
+    // igv.org.genomes / igv.broadinstitute.org buckets.
+    //
+    // config_smoke below is the one that currently loads.
+    // ------------------------------------------------------------------
+
+    // Map and 2D track both verified reachable. The pairing is the one used by
+    // bug-daphne-qin-vanishing-2d-annotation.html, so the genomes match --
+    // every reachable map here is hg38 (chr17 = 83,257,441), while the local
+    // combined_peaks.chr17.txt is hg19 and cannot be paired with them.
+    const config_smoke =
+        {
+            "url": "https://s3.us-east-1.wasabisys.com/aiden-suhas/hic_files/FINAL_GRCh38_processing/LCL/LCL_combined/9_12_23/inter_30.hic",
+            "name": "inter_30.hic",
+            "nvi": "2113712247631,126136",
+            "tracks": [
+                {
+                    "url": "https://www.dropbox.com/scl/fi/mweycro8eyhubrjrhv6oo/fosl1_loops_with_snps_nothresh.bedpe?rlkey=1dv8wbc7c57m9muob7tlxvm89&e=1&st=2c4adj56&dl=0",
+                    "name": "fosl1_loops_with_snps_nothresh.bedpe",
+                    "color": "#00fdff",
+                    "displayMode": "COLLAPSED"
+                }
+            ]
+        };
+
     const config_erez_bug =
         {
             "browsers": [
@@ -230,7 +269,7 @@
             "selectedGene": "egfr"
         };
 
-    juicebox.init(document.getElementById("app-container"), config_2d_track)
+    juicebox.init(document.getElementById("app-container"), config_smoke)
         .then(browser => {
 
             if (Array.isArray(browser)) {

--- a/js/browserCoordinator.js
+++ b/js/browserCoordinator.js
@@ -95,8 +95,7 @@ class BrowserCoordinator {
             this.components.contactMatrix.addMouseHandlers(this.components.contactMatrix.viewportElement);
             this.components.contactMatrix.mouseHandlersEnabled = true;
         }
-        this.components.contactMatrix.clearImageCaches();
-        this.components.contactMatrix.colorScaleThresholdCache = {};
+        this.components.contactMatrix.clearImageCaches({thresholds: true});
 
         // 2. Update chromosome selector
         if (this.components.chromosomeSelector) {
@@ -172,8 +171,7 @@ class BrowserCoordinator {
         }
 
         // ContactMatrixView also needs to know about control map
-        this.components.contactMatrix.clearImageCaches();
-        this.components.contactMatrix.colorScaleThresholdCache = {};
+        this.components.contactMatrix.clearImageCaches({thresholds: true});
 
         // Notify external callbacks
         for (const callback of this.externalCallbacks.onControlMapLoaded) {

--- a/js/browserUIManager.js
+++ b/js/browserUIManager.js
@@ -32,6 +32,8 @@ import ScrollbarWidget from "./scrollbarWidget.js"
 import ColorScale, {defaultColorScaleConfig} from "./colorScale.js"
 import RatioColorScale, {defaultRatioColorScaleConfig} from "./ratioColorScale.js"
 import ContactMatrixView from "./contactMatrixView.js"
+import ImageTileSource from "./imageTileSource.js"
+import {Alert} from "igv-ui"
 import ChromosomeSelector from "./chromosomeSelector.js"
 import AnnotationWidget from "./annotationWidget.js"
 
@@ -85,6 +87,41 @@ class BrowserUIManager {
         this.components.set('colorScale', colorScale);
         this.components.set('ratioColorScale', ratioColorScale);
 
+        const browser = this.browser;
+
+        // diffColorScale is deliberately absent -- AMB has been unimplemented
+        // since 2018 and needs a signed difference scale, not this one. See #426.
+        const imageTileSource = new ImageTileSource({
+            colorScale,
+            ratioColorScale,
+            observer: {
+
+                colorScaleChanged: (scale) => browser.notifyColorScale(scale),
+
+                normalizationUnavailable: (requested, effective) => {
+                    Alert.presentAlert(`Normalization option ${requested} unavailable at this resolution.`);
+                    browser.notifyNormalizationExternalChange(effective);
+                    // The source never writes canonical state, so the correction
+                    // lands here. Still outside the setView chokepoint, as it was
+                    // before -- see the known inconsistency noted in
+                    // docs/state-manipulation.md.
+                    if (browser.state) {
+                        browser.state.normalization = effective;
+                    }
+                },
+
+                // Resolved lazily: contactMatrixView does not exist until the
+                // line below has run.
+                loadingChanged: (isLoading) => {
+                    const view = browser.contactMatrixView;
+                    if (!view) return;
+                    isLoading ? view.startSpinner() : view.stopSpinner();
+                }
+            }
+        });
+
+        this.components.set('imageTileSource', imageTileSource);
+
         // Initialize ContactMatrixView with the components
         const backgroundColor = this.browser.config.backgroundColor || ContactMatrixView.defaultBackgroundColor;
         this.components.set('contactMatrix', new ContactMatrixView(
@@ -92,8 +129,7 @@ class BrowserUIManager {
             this.browser.layoutController.getContactMatrixViewport(),
             sweepZoom,
             scrollbarWidget,
-            colorScale,
-            ratioColorScale,
+            imageTileSource,
             backgroundColor
         ));
     }

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -31,7 +31,7 @@ import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
-import {tileKey, colorScaleKey} from "./imageTileCore.js"
+import {tileKey, colorScaleKey, tileGrid} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
@@ -226,13 +226,8 @@ class ContactMatrixView {
             zdControl = matrixControl.getZoomDataByIndex(controlZoom, "BP");
         }
 
-        const pixelSizeInt = Math.max(1, Math.floor(state.pixelSize));
-        const widthInBins = viewportWidth / pixelSizeInt;
-        const heightInBins = viewportHeight / pixelSizeInt;
-        const blockCol1 = Math.floor(state.x / imageTileDimension);
-        const blockCol2 = Math.floor((state.x + widthInBins) / imageTileDimension);
-        const blockRow1 = Math.floor(state.y / imageTileDimension);
-        const blockRow2 = Math.floor((state.y + heightInBins) / imageTileDimension);
+        const {row1: blockRow1, row2: blockRow2, col1: blockCol1, col2: blockCol2} =
+            tileGrid(state, {width: viewportWidth, height: viewportHeight}, imageTileDimension);
 
         if (state.normalization !== "NONE") {
             if (!ds.hasNormalizationVector(state.normalization, zd.chr1.name, zd.zoom.unit, zd.zoom.binSize)) {

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -25,43 +25,29 @@
  * @author Jim Robinson
  */
 
-import {Alert} from 'igv-ui'
 import {IGVColor} from 'igv-utils'
-import ColorScale from './colorScale.js'
 import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
-import {
-    tileKey,
-    colorScaleKey,
-    tileGrid,
-    resolveDisplayMode,
-    autoThreshold,
-    indexControlRecords,
-    paintRecords
-} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
 const DOUBLE_TAP_TIME_THRESHOLD = 300
 
-const imageTileDimension = 685
-
 const doLegacyTrack2DRendering = false
 
 class ContactMatrixView {
 
-    constructor(browser, viewportElement, sweepZoom, scrollbarWidget, colorScale, ratioColorScale, backgroundColor) {
+    constructor(browser, viewportElement, sweepZoom, scrollbarWidget, imageTileSource, backgroundColor) {
         this.browser = browser;
         this.viewportElement = viewportElement;
         this.sweepZoom = sweepZoom;
         this.scrollbarWidget = scrollbarWidget;
 
-        // Set initial color scales. These might be overridden/adjusted via parameters
-        this.colorScale = colorScale;
-        this.ratioColorScale = ratioColorScale;
-        // this.diffColorScale = new RatioColorScale(100, false);
+        // Supplies the image tiles this view paints. Owns the color scales, the
+        // tile cache and rasterization. See CONTEXT.md.
+        this.imageTileSource = imageTileSource;
 
         this.backgroundColor = backgroundColor;
         this.backgroundRGBString = IGVColor.rgbColor(backgroundColor.r, backgroundColor.g, backgroundColor.b);
@@ -76,10 +62,6 @@ class ContactMatrixView {
         this.yGuideElement = viewportElement.querySelector("div[id$='-y-guide']");
 
         this.displayMode = 'A';
-        this.imageTileCache = {};
-        this.imageTileCacheKeys = [];
-        this.imageTileCacheLimit = 8; // 8 is the minimum number required to support A/B cycling
-        this.colorScaleThresholdCache = {};
 
         // Note: MapLoad and ControlMapLoad subscriptions removed - now handled by BrowserCoordinator
         // NormalizationChange, TrackLoad2D, TrackState2D, and ColorChange are still posted to eventBus
@@ -88,8 +70,21 @@ class ContactMatrixView {
         this.browser.eventBus.subscribe("TrackLoad2D", this);
         this.browser.eventBus.subscribe("TrackState2D", this);
         this.browser.eventBus.subscribe("ColorChange", this);
+    }
 
-        this.drawsInProgress = new Set();
+    // The color scales live on the image tile source. These read-through
+    // accessors keep the existing call sites in hicBrowser, browserCoordinator
+    // and hicColorScaleWidget working unchanged.
+    get colorScale() {
+        return this.imageTileSource.colorScale;
+    }
+
+    get ratioColorScale() {
+        return this.imageTileSource.ratioColorScale;
+    }
+
+    get diffColorScale() {
+        return this.imageTileSource.diffColorScale;
     }
 
     setBackgroundColor(rgb) {
@@ -108,38 +103,16 @@ class ContactMatrixView {
     }
 
     setColorScale(colorScale) {
-
-        switch (this.displayMode) {
-            case 'AOB':
-            case 'BOA':
-                this.ratioColorScale = colorScale
-                break
-            case 'AMB':
-                this.diffColorScale = colorScale
-                break
-            default:
-                this.colorScale = colorScale
-        }
-        this.colorScaleThresholdCache[colorScaleKey(this.browser.state, this.displayMode)] = colorScale.threshold
+        this.imageTileSource.setColorScale(colorScale, this.displayMode, this.browser.state)
     }
 
     async setColorScaleThreshold(threshold) {
-        this.getColorScale().setThreshold(threshold)
-        this.colorScaleThresholdCache[colorScaleKey(this.browser.state, this.displayMode)] = threshold
-        this.imageTileCache = {}
+        this.imageTileSource.setThreshold(threshold, this.displayMode, this.browser.state)
         await this.update()
     }
 
     getColorScale() {
-        switch (this.displayMode) {
-            case 'AOB':
-            case 'BOA':
-                return this.ratioColorScale
-            case 'AMB':
-                return this.diffColorScale
-            default:
-                return this.colorScale
-        }
+        return this.imageTileSource.getColorScale(this.displayMode)
     }
 
     async setDisplayMode(mode) {
@@ -148,9 +121,12 @@ class ContactMatrixView {
         await this.update()
     }
 
-    clearImageCaches() {
-        this.imageTileCache = {}
-        this.imageTileCacheKeys = []
+    /**
+     * @param {boolean} thresholds also discard computed color scale thresholds.
+     *        Map load passes true; a pan or color change does not.
+     */
+    clearImageCaches({thresholds = false} = {}) {
+        this.imageTileSource.invalidate({thresholds})
     }
 
     getViewDimensions() {
@@ -168,8 +144,7 @@ class ContactMatrixView {
                 this.addMouseHandlers(this.viewportElement)
                 this.mouseHandlersEnabled = true;
             }
-            this.clearImageCaches();
-            this.colorScaleThresholdCache = {};
+            this.clearImageCaches({thresholds: true});
         } else {
             if (event.type !== "LocusChange") {
                 this.clearImageCaches();
@@ -205,288 +180,61 @@ class ContactMatrixView {
             this.canvasElement.setAttribute('height', viewportHeight);
         }
 
-        const { state, dataset, controlDataset } = this.browser;
-        let zdControl = null;
+        const {state, dataset, controlDataset} = this.browser;
 
-        const {ds, dsControl, zoom, controlZoom} =
-            resolveDisplayMode(dataset, controlDataset, state.zoom, this.displayMode);
-
-        const matrix = await ds.getMatrix(state.chr1, state.chr2);
-        const zd = matrix.getZoomDataByIndex(zoom, "BP");
-
-        if (dsControl) {
-            const matrixControl = await dsControl.getMatrix(state.chr1, state.chr2);
-            zdControl = matrixControl.getZoomDataByIndex(controlZoom, "BP");
-        }
-
-        const {row1: blockRow1, row2: blockRow2, col1: blockCol1, col2: blockCol2} =
-            tileGrid(state, {width: viewportWidth, height: viewportHeight}, imageTileDimension);
-
-        if (state.normalization !== "NONE") {
-            if (!ds.hasNormalizationVector(state.normalization, zd.chr1.name, zd.zoom.unit, zd.zoom.binSize)) {
-                Alert.presentAlert(`Normalization option ${state.normalization} unavailable at this resolution.`);
-                this.browser.notifyNormalizationExternalChange("NONE");
-                state.normalization = "NONE";
-            }
-        }
-
-        await this.checkColorScale(ds, zd, blockRow1, blockRow2, blockCol1, blockCol2, state.normalization);
-
-        this.ctx.clearRect(0, 0, viewportWidth, viewportHeight);
-        for (let r = blockRow1; r <= blockRow2; r++) {
-            for (let c = blockCol1; c <= blockCol2; c++) {
-                const tile = await this.getImageTile(ds, dsControl, zd, zdControl, r, c, state);
-                if (tile.image) this.paintTile(tile);
-            }
-        }
-
-        this.genomicExtent = {
+        // Content is fixed for the pass; placement stays live, so tiles that
+        // resolve late during a pan land where the view is now rather than
+        // where it was when the pass started. See CONTEXT.md.
+        const snapshot = {
             chr1: state.chr1,
             chr2: state.chr2,
-            x: state.x * zd.zoom.binSize,
-            y: state.y * zd.zoom.binSize,
-            w: viewportWidth * zd.zoom.binSize / state.pixelSize,
-            h: viewportHeight * zd.zoom.binSize / state.pixelSize
+            x: state.x,
+            y: state.y,
+            zoom: state.zoom,
+            pixelSize: state.pixelSize,
+            normalization: state.normalization
         };
-    }
 
-    /**
-     * This is where the image tile is actually drawn, if not in the cache
-     *
-     * @param ds
-     * @param dsControl
-     * @param zd
-     * @param zdControl
-     * @param row
-     * @param column
-     * @param state
-     * @returns {Promise<{image: HTMLCanvasElement, column: *, row: *, blockBinCount}|{image, inProgress: boolean, column: *, row: *, blockBinCount}|*>}
-     */
-    async getImageTile(ds, dsControl, zd, zdControl, row, column, state) {
+        const tiles = this.imageTileSource.tilesFor({
+            dataset,
+            controlDataset,
+            state: snapshot,
+            displayMode: this.displayMode,
+            viewDimensions: {width: viewportWidth, height: viewportHeight}
+        });
 
-        const key = tileKey(zd, row, column, state.normalization, this.displayMode)
+        // Cleared on the first tile rather than up front: the source resolves
+        // matrices and may fetch for the color scale before yielding anything,
+        // and blanking the viewport for that window would flicker on every pass.
+        let cleared = false;
+        let binSize;
 
-        if (this.imageTileCache.hasOwnProperty(key)) {
-            return this.imageTileCache[key]
+        for await (const tile of tiles) {
 
-        } else {
-            if (this.drawsInProgress.has(key)) {
-                //console.log("In progress")
-                const imageSize = imageTileDimension
-                const image = inProgressTile(imageSize)
-                return {
-                    row: row,
-                    column: column,
-                    blockBinCount: imageTileDimension,
-                    image: image,
-                    inProgress: true
-                }  // TODO return an image at a coarser resolution if avaliable
-
+            if (!cleared) {
+                this.ctx.clearRect(0, 0, viewportWidth, viewportHeight);
+                cleared = true;
             }
-            this.drawsInProgress.add(key)
 
-            try {
-                this.startSpinner()
-                const sameChr = zd.chr1.index === zd.chr2.index
-                const transpose = sameChr && row < column
-                const averageCount = zd.averageCount
-                const ctrlAverageCount = zdControl ? zdControl.averageCount : 1
+            binSize = tile.binSize;
 
-                const imageSize = imageTileDimension
-                const image = document.createElement('canvas')
-                image.width = imageSize
-                image.height = imageSize
-                const ctx = image.getContext('2d')
-                //ctx.clearRect(0, 0, image.width, image.height);
-
-                // Get blocks
-                const widthInBP = imageTileDimension * zd.zoom.binSize
-                const x0bp = column * widthInBP
-                const region1 = {chr: zd.chr1.name, start: x0bp, end: x0bp + widthInBP}
-                const y0bp = row * widthInBP
-                const region2 = {chr: zd.chr2.name, start: y0bp, end: y0bp + widthInBP}
-                const records = await ds.getContactRecords(state.normalization, region1, region2, zd.zoom.unit, zd.zoom.binSize)
-                let cRecords
-                if (zdControl) {
-                    cRecords = await dsControl.getContactRecords(state.normalization, region1, region2, zdControl.zoom.unit, zdControl.zoom.binSize)
-                }
-
-                if (records.length > 0) {
-
-                    const controlRecords = indexControlRecords(cRecords, this.displayMode)
-
-                    const id = ctx.getImageData(0, 0, image.width, image.height)
-
-                    // TODO -- verify that this bitblting is faster than fillRect
-                    paintRecords(id, records, controlRecords, {
-                        displayMode: this.displayMode,
-                        tileDimension: imageTileDimension,
-                        sameChr,
-                        averageCount,
-                        ctrlAverageCount,
-                        colorScale: this.colorScale,
-                        ratioColorScale: this.ratioColorScale,
-                        diffColorScale: this.diffColorScale
-                    }, row, column)
-
-                    ctx.putImageData(id, 0, 0)
-                }
-
-
-                if (true === doLegacyTrack2DRendering) {
-
-                    //Draw 2D tracks
-                    ctx.save()
-                    ctx.lineWidth = 2
-
-                    const onDiagonalTile = sameChr && row === column
-
-                    for (let track2D of this.browser.tracks2D) {
-                        const skip =
-                            !track2D.isVisible ||
-                            (sameChr && "lower" === track2D.displayMode  && row < column) ||
-                            (sameChr && "upper" === track2D.displayMode && row > column)
-
-                        if (!skip) {
-
-                            const chr1Name = zd.chr1.name
-                            const chr2Name = zd.chr2.name
-
-                            const features = track2D.getFeatures(chr1Name, chr2Name)
-
-                            if (features) {
-
-                                for (let {chr1, x1, x2, y1, y2, color} of features) {
-
-                                    ctx.strokeStyle = track2D.color || color
-
-                                    // Chr name order -- test for equality of zoom data chr1 and feature chr1
-                                    const flip = chr1Name !== chr1
-
-                                    //Note: transpose = sameChr && row < column
-                                    const fx1 = transpose || flip ? y1 : x1
-                                    const fx2 = transpose || flip ? y2 : x2
-                                    const fy1 = transpose || flip ? x1 : y1
-                                    const fy2 = transpose || flip ? x2 : y2
-
-                                    let px1 = (fx1 - x0bp) / zd.zoom.binSize
-                                    let px2 = (fx2 - x0bp) / zd.zoom.binSize
-                                    let py1 = (fy1 - y0bp) / zd.zoom.binSize
-                                    let py2 = (fy2 - y0bp) / zd.zoom.binSize
-                                    let w = px2 - px1
-                                    let h = py2 - py1
-
-                                    const dim = Math.max(image.width, image.height)
-                                    if (px2 > 0 && px1 < dim && py2 > 0 && py1 < dim) {
-
-
-                                        if (!onDiagonalTile || "upper" !== track2D.displayMode) {
-                                            ctx.strokeRect(px1, py1, w, h)
-                                        }
-
-                                        // By convention intra-chromosome data is always stored in lower diagonal coordinates.
-                                        // If we are on a diagonal tile, draw the symmetrical reflection unless display mode is lower
-                                        if (onDiagonalTile && "lower" !== track2D.displayMode) {
-                                            ctx.strokeRect(py1, px1, h, w)
-                                        }
-                                    }
-                                }
-
-                            } // if (features)
-
-                        }
-                    }
-
-                    ctx.restore()
-
-                } // if (true === doLegacyTrack2DRendering)
-
-                // Uncomment to reveal tile boundaries for debugging.
-                // ctx.strokeStyle = "rgb(255,255,255)"
-                // ctx.strokeStyle = "pink"
-                // ctx.strokeRect(0, 0, image.width - 1, image.height - 1)
-
-                const imageTile = { row, column, blockBinCount: imageTileDimension, image }
-
-                if (this.imageTileCacheLimit > 0) {
-                    if (this.imageTileCacheKeys.length > this.imageTileCacheLimit) {
-                        delete this.imageTileCache[this.imageTileCacheKeys[0]]
-                        this.imageTileCacheKeys.shift()
-                    }
-                    this.imageTileCache[key] = imageTile
-
-                }
-
-                return imageTile
-
-            } finally {
-                this.drawsInProgress.delete(key)
-                this.stopSpinner()
+            if (tile.inProgress) {
+                this.paintTile({...tile, image: inProgressTile(tile.blockBinCount)});
+            } else if (tile.image) {
+                this.paintTile(tile);
             }
         }
 
-
-    }
-
-    /**
-     * Return a promise to adjust the color scale, if needed.  This function might need to load the contact
-     * data to computer scale.
-     *
-     * @param zd
-     * @param row1
-     * @param row2
-     * @param col1
-     * @param col2
-     * @param normalization
-     * @returns {*}
-     */
-    async checkColorScale(ds, zd, row1, row2, col1, col2, normalization) {
-
-        // Safety check: ensure state exists before accessing it
-        if (!this.browser.state) {
-            return this.colorScale;
+        if (undefined !== binSize) {
+            this.genomicExtent = {
+                chr1: state.chr1,
+                chr2: state.chr2,
+                x: state.x * binSize,
+                y: state.y * binSize,
+                w: viewportWidth * binSize / state.pixelSize,
+                h: viewportHeight * binSize / state.pixelSize
+            };
         }
-
-        const colorKey = colorScaleKey(this.browser.state, this.displayMode)   // This doesn't feel right, state should be an argument
-        if ('AOB' === this.displayMode || 'BOA' === this.displayMode) {
-            return this.ratioColorScale     // Don't adjust color scale for A/B.
-        }
-
-        if (this.colorScaleThresholdCache[colorKey]) {
-            const changed = this.colorScale.threshold !== this.colorScaleThresholdCache[colorKey]
-            this.colorScale.setThreshold(this.colorScaleThresholdCache[colorKey])
-            if (changed) {
-                this.browser.notifyColorScale(this.colorScale)
-            }
-            return this.colorScale
-        } else {
-            try {
-                const widthInBP = imageTileDimension * zd.zoom.binSize
-                const x0bp = col1 * widthInBP
-                const xWidthInBP = (col2 - col1 + 1) * widthInBP
-                const region1 = {chr: zd.chr1.name, start: x0bp, end: x0bp + xWidthInBP}
-                const y0bp = row1 * widthInBP
-                const yWidthInBp = (row2 - row1 + 1) * widthInBP
-                const region2 = {chr: zd.chr2.name, start: y0bp, end: y0bp + yWidthInBp}
-                const records = await ds.getContactRecords(normalization, region1, region2, zd.zoom.unit, zd.zoom.binSize, true)
-
-                const s = autoThreshold(records, {isLive: ds.isLive, isWholeGenome: 0 === zd.chr1.index})
-                if (undefined !== s) {
-                    this.colorScale = new ColorScale(this.colorScale)
-                    this.colorScale.setThreshold(s)
-                    this.computeColorScale = false
-                    this.browser.notifyColorScale(this.colorScale)
-                    this.colorScaleThresholdCache[colorKey] = s
-                }
-
-                return this.colorScale
-            } finally {
-                this.stopSpinner()
-            }
-
-
-        }
-
     }
 
     async zoomIn() {

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -31,7 +31,7 @@ import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
-import {tileKey, colorScaleKey, tileGrid} from "./imageTileCore.js"
+import {tileKey, colorScaleKey, tileGrid, resolveDisplayMode} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
@@ -197,26 +197,10 @@ class ContactMatrixView {
         }
 
         const { state, dataset, controlDataset } = this.browser;
-        let ds = dataset, dsControl = null, zdControl = null;
-        let zoom = state.zoom, controlZoom;
+        let zdControl = null;
 
-        switch (this.displayMode) {
-            case 'B':
-                zoom = getBZoomIndex(state.zoom);
-                ds = controlDataset;
-                break;
-            case 'AOB':
-            case 'AMB':
-                controlZoom = getBZoomIndex(state.zoom);
-                dsControl = controlDataset;
-                break;
-            case 'BOA':
-                zoom = getBZoomIndex(state.zoom);
-                controlZoom = state.zoom;
-                ds = controlDataset;
-                dsControl = dataset;
-                break;
-        }
+        const {ds, dsControl, zoom, controlZoom} =
+            resolveDisplayMode(dataset, controlDataset, state.zoom, this.displayMode);
 
         const matrix = await ds.getMatrix(state.chr1, state.chr2);
         const zd = matrix.getZoomDataByIndex(zoom, "BP");
@@ -255,16 +239,6 @@ class ContactMatrixView {
             w: viewportWidth * zd.zoom.binSize / state.pixelSize,
             h: viewportHeight * zd.zoom.binSize / state.pixelSize
         };
-
-        function getBZoomIndex(zoom) {
-            const binSize = dataset.getBinSizeForZoomIndex(zoom);
-            if (!binSize) throw new Error(`Invalid zoom (resolution) index: ${zoom}`);
-
-            const bZoom = controlDataset.getZoomIndexForBinSize(binSize);
-            if (bZoom < 0) throw new Error(`Invalid binSize for "B" map: ${binSize}`);
-
-            return bZoom;
-        }
     }
 
     /**

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -31,6 +31,7 @@ import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
+import {tileKey, colorScaleKey} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
@@ -285,7 +286,7 @@ class ContactMatrixView {
      */
     async getImageTile(ds, dsControl, zd, zdControl, row, column, state) {
 
-        const key = `${zd.chr1.name}_${zd.chr2.name}_${zd.zoom.binSize}_${zd.zoom.unit}_${row}_${column}_${state.normalization}_${this.displayMode}`
+        const key = tileKey(zd, row, column, state.normalization, this.displayMode)
 
         if (this.imageTileCache.hasOwnProperty(key)) {
             return this.imageTileCache[key]
@@ -1045,14 +1046,6 @@ class ContactMatrixView {
 }
 
 ContactMatrixView.defaultBackgroundColor = {r: 255, g: 255, b: 255}
-
-function colorScaleKey(state, displayMode) {
-    // Safety check: ensure state exists before accessing its properties
-    if (!state) {
-        return "unknown_" + displayMode;
-    }
-    return "" + state.chr1 + "_" + state.chr2 + "_" + state.zoom + "_" + state.normalization + "_" + displayMode
-}
 
 /**
  * Returns a promise for an image tile

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -25,6 +25,7 @@
  * @author Jim Robinson
  */
 
+import {Alert} from 'igv-ui'
 import {IGVColor} from 'igv-utils'
 import ColorScale from './colorScale.js'
 import HICEvent from './hicEvent.js'

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -31,7 +31,15 @@ import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
-import {tileKey, colorScaleKey, tileGrid, resolveDisplayMode, autoThreshold} from "./imageTileCore.js"
+import {
+    tileKey,
+    colorScaleKey,
+    tileGrid,
+    resolveDisplayMode,
+    autoThreshold,
+    indexControlRecords,
+    paintRecords
+} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
@@ -282,7 +290,6 @@ class ContactMatrixView {
                 const transpose = sameChr && row < column
                 const averageCount = zd.averageCount
                 const ctrlAverageCount = zdControl ? zdControl.averageCount : 1
-                const averageAcrossMapAndControl = (averageCount + ctrlAverageCount) / 2
 
                 const imageSize = imageTileDimension
                 const image = document.createElement('canvas')
@@ -305,69 +312,21 @@ class ContactMatrixView {
 
                 if (records.length > 0) {
 
-                    const controlRecords = {}
-                    if ('AOB' === this.displayMode || 'BOA' === this.displayMode || 'AMB' === this.displayMode) {
-                        for (let record of cRecords) {
-                            controlRecords[record.getKey()] = record
-                        }
-                    }
+                    const controlRecords = indexControlRecords(cRecords, this.displayMode)
 
-                    let id = ctx.getImageData(0, 0, image.width, image.height)
+                    const id = ctx.getImageData(0, 0, image.width, image.height)
 
-
-                    const x0 = transpose ? row * imageTileDimension : column * imageTileDimension
-                    const y0 = transpose ? column * imageTileDimension : row * imageTileDimension
-                    for (let i = 0; i < records.length; i++) {
-
-                        const rec = records[i]
-                        let x = Math.floor((rec.bin1 - x0))
-                        let y = Math.floor((rec.bin2 - y0))
-
-                        if (transpose) {
-                            const t = y
-                            y = x
-                            x = t
-                        }
-
-                        let rgba
-                        switch (this.displayMode) {
-
-                            case 'AOB':
-                            case 'BOA':
-                                let key = rec.getKey()
-                                let controlRec = controlRecords[key]
-                                if (!controlRec) {
-                                    continue    // Skip
-                                }
-                                let score = (rec.counts / averageCount) / (controlRec.counts / ctrlAverageCount)
-
-                                rgba = this.ratioColorScale.getColor(score)
-
-                                break
-
-                            case 'AMB':
-                                key = rec.getKey()
-                                controlRec = controlRecords[key]
-                                if (!controlRec) {
-                                    continue    // Skip
-                                }
-                                score = averageAcrossMapAndControl * ((rec.counts / averageCount) - (controlRec.counts / ctrlAverageCount))
-
-                                rgba = this.diffColorScale.getColor(score)
-
-                                break
-
-                            default:    // Either 'A' or 'B'
-                                rgba = this.colorScale.getColor(rec.counts)
-                        }
-
-                        // TODO -- verify that this bitblting is faster than fillRect
-                        setPixel(id, x, y, rgba.red, rgba.green, rgba.blue, rgba.alpha)
-                        if (sameChr && row === column) {
-                            setPixel(id, y, x, rgba.red, rgba.green, rgba.blue, rgba.alpha)
-                        }
-
-                    }
+                    // TODO -- verify that this bitblting is faster than fillRect
+                    paintRecords(id, records, controlRecords, {
+                        displayMode: this.displayMode,
+                        tileDimension: imageTileDimension,
+                        sameChr,
+                        averageCount,
+                        ctrlAverageCount,
+                        colorScale: this.colorScale,
+                        ratioColorScale: this.ratioColorScale,
+                        diffColorScale: this.diffColorScale
+                    }, row, column)
 
                     ctx.putImageData(id, 0, 0)
                 }
@@ -465,14 +424,6 @@ class ContactMatrixView {
             }
         }
 
-
-        function setPixel(imageData, x, y, r, g, b, a) {
-            const index = (x + y * imageData.width) * 4
-            imageData.data[index + 0] = r
-            imageData.data[index + 1] = g
-            imageData.data[index + 2] = b
-            imageData.data[index + 3] = a
-        }
 
     }
 

--- a/js/contactMatrixView.js
+++ b/js/contactMatrixView.js
@@ -31,7 +31,7 @@ import HICEvent from './hicEvent.js'
 import * as hicUtils from './hicUtils.js'
 import {getLocus} from "./genomicUtils.js"
 import {getOffset} from "./utils.js"
-import {tileKey, colorScaleKey, tileGrid, resolveDisplayMode} from "./imageTileCore.js"
+import {tileKey, colorScaleKey, tileGrid, resolveDisplayMode, autoThreshold} from "./imageTileCore.js"
 
 const DRAG_THRESHOLD = 2
 const DOUBLE_TAP_DIST_THRESHOLD = 20
@@ -518,14 +518,8 @@ class ContactMatrixView {
                 const region2 = {chr: zd.chr2.name, start: y0bp, end: y0bp + yWidthInBp}
                 const records = await ds.getContactRecords(normalization, region1, region2, zd.zoom.unit, zd.zoom.binSize, true)
 
-                // Live maps emit ensemble contact frequencies bounded in (0, 1];
-                // the .hic heuristics (95th percentile, ×4 for whole-genome) overshoot
-                // that ceiling and leave the +/- threshold buttons with no usable range.
-                const p = ds.isLive ? 75 : 95
-                let s = computePercentile(records, p)
-                if (!isNaN(s)) {  // Can return NaN if all blocks are empty
-                    if (!ds.isLive && 0 === zd.chr1.index) s *= 4   // Heuristic for whole genome view
-                    if (ds.isLive) s = Math.min(s, 1)               // Clamp to frequency ceiling
+                const s = autoThreshold(records, {isLive: ds.isLive, isWholeGenome: 0 === zd.chr1.index})
+                if (undefined !== s) {
                     this.colorScale = new ColorScale(this.colorScale)
                     this.colorScale.setThreshold(s)
                     this.computeColorScale = false
@@ -1062,17 +1056,6 @@ function getMatrices(chr1, chr2) {
         }
     }
     return Promise.all(promises)
-}
-
-function computePercentile(records, p) {
-    const counts = records.map(r => r.counts)
-    counts.sort(function (a, b) {
-        return a - b
-    })
-    const idx = Math.floor((p / 100) * records.length)
-    return counts[idx]
-
-    // return HICMath.percentile(array, p);
 }
 
 export default ContactMatrixView

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -179,10 +179,6 @@ class HICBrowser {
                 this.state.normalization = validNormalizations.has(config.normalization) ? config.normalization : 'NONE';
             }
 
-            // No longer need hold/release - notifications happen directly
-            const tmp = this.contactMatrixView.colorScaleThresholdCache;
-            this.contactMatrixView.colorScaleThresholdCache = tmp;
-
             if (config.cycle) {
                 this.ui.getComponent('controlMap').toggleDisplayModeCycle();
             } else {
@@ -894,8 +890,7 @@ class HICBrowser {
     }
 
     repaintMatrix() {
-        this.contactMatrixView.imageTileCache = {}
-        this.contactMatrixView.initialImage = undefined
+        this.contactMatrixView.clearImageCaches()
         this.contactMatrixView.update()
     }
 

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 The Regents of the University of California
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Pure functions behind the image tile source.
+ *
+ * An "image tile" is a square raster of the contact matrix at a given zoom, row
+ * and column. It is distinct from a "track tile" (js/tile.js), which is a
+ * buffered span of 1D track features for one axis.
+ *
+ * Everything in this module is free of DOM, browser and dataset dependencies so
+ * it can be exercised directly from tests. See CONTEXT.md.
+ */
+
+/**
+ * Cache key for a single image tile.
+ *
+ * Identifies tile content exactly: the chromosome pair, resolution, unit, grid
+ * position, normalization and display mode. Notably it does NOT include x, y or
+ * pixelSize -- those affect where a tile is painted, not what it contains.
+ *
+ * @param zd zoom data
+ * @param {number} row tile row
+ * @param {number} column tile column
+ * @param {string} normalization normalization vector id
+ * @param {string} displayMode one of 'A', 'B', 'AOB', 'BOA', 'AMB'
+ * @returns {string}
+ */
+function tileKey(zd, row, column, normalization, displayMode) {
+    return `${zd.chr1.name}_${zd.chr2.name}_${zd.zoom.binSize}_${zd.zoom.unit}_${row}_${column}_${normalization}_${displayMode}`
+}
+
+/**
+ * Cache key for a computed color scale threshold.
+ *
+ * Coarser than tileKey -- a threshold is shared by every tile in the view, so
+ * the key omits grid position, unit and binSize, keying on zoom index instead.
+ *
+ * @param state canonical state, or undefined during startup
+ * @param {string} displayMode
+ * @returns {string}
+ */
+function colorScaleKey(state, displayMode) {
+    // Safety check: ensure state exists before accessing its properties
+    if (!state) {
+        return "unknown_" + displayMode
+    }
+    return "" + state.chr1 + "_" + state.chr2 + "_" + state.zoom + "_" + state.normalization + "_" + displayMode
+}
+
+export { tileKey, colorScaleKey }

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -161,4 +161,47 @@ function resolveDisplayMode(dataset, controlDataset, zoom, displayMode) {
     return {ds, dsControl, zoom, controlZoom}
 }
 
-export { tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode }
+/**
+ * The p-th percentile of contact counts.
+ *
+ * Returns undefined when there are no records -- the index lands past the end
+ * of the sorted array. Callers must treat that as "no threshold available"
+ * rather than zero.
+ */
+function computePercentile(records, p) {
+    const counts = records.map(r => r.counts)
+    counts.sort(function (a, b) {
+        return a - b
+    })
+    const idx = Math.floor((p / 100) * records.length)
+    return counts[idx]
+}
+
+/**
+ * Threshold for the automatically-computed color scale.
+ *
+ * Two families of map need different treatment:
+ *
+ * - .hic maps carry raw contact counts with a long tail, so the 95th percentile
+ *   is used, scaled x4 at whole-genome view where averaging across chromosomes
+ *   depresses the percentile.
+ * - Live maps emit ensemble contact frequencies bounded in (0, 1]. The .hic
+ *   heuristics overshoot that ceiling and leave the +/- threshold buttons with
+ *   no usable range, so a lower percentile is used and the result is clamped.
+ *
+ * @param records contact records
+ * @param {{isLive: boolean, isWholeGenome: boolean}} options
+ * @returns {number|undefined} undefined when no threshold can be computed
+ */
+function autoThreshold(records, {isLive, isWholeGenome}) {
+
+    const s = computePercentile(records, isLive ? 75 : 95)
+
+    if (isNaN(s)) return undefined      // no records, or all blocks empty
+
+    if (isLive) return Math.min(s, 1)   // clamp to the frequency ceiling
+
+    return isWholeGenome ? s * 4 : s
+}
+
+export { tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode, computePercentile, autoThreshold }

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -98,4 +98,67 @@ function tileGrid(state, viewDimensions, tileDimension) {
     }
 }
 
-export { tileKey, colorScaleKey, tileGrid }
+/**
+ * Translate a zoom index on the primary map to the equivalent index on the
+ * control map.
+ *
+ * The two maps are matched by resolution, not by index -- a control map may
+ * carry a different set of bin sizes, so index N on A is not index N on B.
+ *
+ * @throws if the zoom index is not present on the primary map, or the resulting
+ *         bin size is not present on the control map
+ */
+function bZoomIndex(dataset, controlDataset, zoom) {
+
+    const binSize = dataset.getBinSizeForZoomIndex(zoom)
+    if (!binSize) throw new Error(`Invalid zoom (resolution) index: ${zoom}`)
+
+    const bZoom = controlDataset.getZoomIndexForBinSize(binSize)
+    if (bZoom < 0) throw new Error(`Invalid binSize for "B" map: ${binSize}`)
+
+    return bZoom
+}
+
+/**
+ * Which dataset is rendered, which is the control, and at what zoom index each.
+ *
+ * Display modes:
+ *   A    -- primary only
+ *   B    -- control only, rendered as if it were primary
+ *   AOB  -- A over B, ratio
+ *   AMB  -- A minus B, difference
+ *   BOA  -- B over A, ratio with the roles swapped
+ *
+ * Only the modes that read the control map translate the zoom index; A leaves
+ * everything at the incoming values.
+ *
+ * @returns {{ds: *, dsControl: *, zoom: number, controlZoom: number|undefined}}
+ */
+function resolveDisplayMode(dataset, controlDataset, zoom, displayMode) {
+
+    let ds = dataset
+    let dsControl = null
+    let controlZoom
+
+    switch (displayMode) {
+        case 'B':
+            zoom = bZoomIndex(dataset, controlDataset, zoom)
+            ds = controlDataset
+            break
+        case 'AOB':
+        case 'AMB':
+            controlZoom = bZoomIndex(dataset, controlDataset, zoom)
+            dsControl = controlDataset
+            break
+        case 'BOA':
+            controlZoom = zoom
+            zoom = bZoomIndex(dataset, controlDataset, zoom)
+            ds = controlDataset
+            dsControl = dataset
+            break
+    }
+
+    return {ds, dsControl, zoom, controlZoom}
+}
+
+export { tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode }

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -204,4 +204,129 @@ function autoThreshold(records, {isLive, isWholeGenome}) {
     return isWholeGenome ? s * 4 : s
 }
 
-export { tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode, computePercentile, autoThreshold }
+function setPixel(buf, x, y, r, g, b, a) {
+    const index = (x + y * buf.width) * 4
+    buf.data[index + 0] = r
+    buf.data[index + 1] = g
+    buf.data[index + 2] = b
+    buf.data[index + 3] = a
+}
+
+/**
+ * Index control-map records by bin pair, for the modes that combine two maps.
+ *
+ * Returns an empty index for the single-map modes, which never consult it.
+ */
+function indexControlRecords(controlRecordList, displayMode) {
+
+    const index = {}
+    if ('AOB' === displayMode || 'BOA' === displayMode || 'AMB' === displayMode) {
+        for (const record of controlRecordList) {
+            index[record.getKey()] = record
+        }
+    }
+    return index
+}
+
+/**
+ * Rasterize contact records into a pixel buffer.
+ *
+ * The buffer is any object shaped like ImageData -- {width, height, data} where
+ * data is a Uint8ClampedArray of RGBA quads. In production it comes from
+ * getImageData on a tile canvas; in tests it is a plain object.
+ *
+ * Intra-chromosomal data is stored in lower-diagonal coordinates by convention.
+ * Two consequences are handled here:
+ *
+ * - Tiles above the diagonal (row < column) are read from their mirrored
+ *   position and transposed on the way in.
+ * - Tiles ON the diagonal are painted twice, reflected, so the upper triangle
+ *   is filled from the same records.
+ *
+ * Records with no matching control record are skipped entirely in the combining
+ * modes -- they leave the buffer untouched rather than painting a zero score.
+ *
+ * @param buf {{width: number, height: number, data: Uint8ClampedArray}}
+ * @param records primary map contact records
+ * @param controlRecords control records indexed by bin pair, from indexControlRecords
+ * @param plan {{displayMode, tileDimension, sameChr, averageCount, ctrlAverageCount,
+ *               colorScale, ratioColorScale, diffColorScale}}
+ * @param {number} row tile row
+ * @param {number} column tile column
+ * @returns {number} how many records were painted, excluding those skipped
+ */
+function paintRecords(buf, records, controlRecords, plan, row, column) {
+
+    const {
+        displayMode, tileDimension, sameChr,
+        averageCount, ctrlAverageCount,
+        colorScale, ratioColorScale, diffColorScale
+    } = plan
+
+    const transpose = sameChr && row < column
+    const onDiagonal = sameChr && row === column
+    const averageAcrossMapAndControl = (averageCount + ctrlAverageCount) / 2
+
+    const x0 = (transpose ? row : column) * tileDimension
+    const y0 = (transpose ? column : row) * tileDimension
+
+    let painted = 0
+
+    for (const rec of records) {
+
+        let x = Math.floor(rec.bin1 - x0)
+        let y = Math.floor(rec.bin2 - y0)
+
+        if (transpose) {
+            const t = y
+            y = x
+            x = t
+        }
+
+        let rgba
+
+        switch (displayMode) {
+
+            case 'AOB':
+            case 'BOA': {
+                const controlRec = controlRecords[rec.getKey()]
+                if (!controlRec) continue    // Skip
+                const score = (rec.counts / averageCount) / (controlRec.counts / ctrlAverageCount)
+                rgba = ratioColorScale.getColor(score)
+                break
+            }
+
+            case 'AMB': {
+                const controlRec = controlRecords[rec.getKey()]
+                if (!controlRec) continue    // Skip
+                const score = averageAcrossMapAndControl * ((rec.counts / averageCount) - (controlRec.counts / ctrlAverageCount))
+                rgba = diffColorScale.getColor(score)
+                break
+            }
+
+            default:    // Either 'A' or 'B'
+                rgba = colorScale.getColor(rec.counts)
+        }
+
+        setPixel(buf, x, y, rgba.red, rgba.green, rgba.blue, rgba.alpha)
+        if (onDiagonal) {
+            setPixel(buf, y, x, rgba.red, rgba.green, rgba.blue, rgba.alpha)
+        }
+
+        painted++
+    }
+
+    return painted
+}
+
+export {
+    tileKey,
+    colorScaleKey,
+    tileGrid,
+    bZoomIndex,
+    resolveDisplayMode,
+    computePercentile,
+    autoThreshold,
+    indexControlRecords,
+    paintRecords
+}

--- a/js/imageTileCore.js
+++ b/js/imageTileCore.js
@@ -69,4 +69,33 @@ function colorScaleKey(state, displayMode) {
     return "" + state.chr1 + "_" + state.chr2 + "_" + state.zoom + "_" + state.normalization + "_" + displayMode
 }
 
-export { tileKey, colorScaleKey }
+/**
+ * The inclusive range of image tiles covering the current view.
+ *
+ * Bin extent is derived from an integer pixel size -- the fractional pixelSize
+ * carried in canonical state is floored (and floored at 1) before dividing, so
+ * the covered range never collapses to zero at sub-pixel resolutions.
+ *
+ * The range is inclusive on both ends: a view whose right edge falls exactly on
+ * a tile boundary still includes that boundary tile.
+ *
+ * @param state canonical state -- reads x, y, pixelSize
+ * @param {{width: number, height: number}} viewDimensions
+ * @param {number} tileDimension tile edge length in bins
+ * @returns {{row1: number, row2: number, col1: number, col2: number}}
+ */
+function tileGrid(state, viewDimensions, tileDimension) {
+
+    const pixelSizeInt = Math.max(1, Math.floor(state.pixelSize))
+    const widthInBins = viewDimensions.width / pixelSizeInt
+    const heightInBins = viewDimensions.height / pixelSizeInt
+
+    return {
+        col1: Math.floor(state.x / tileDimension),
+        col2: Math.floor((state.x + widthInBins) / tileDimension),
+        row1: Math.floor(state.y / tileDimension),
+        row2: Math.floor((state.y + heightInBins) / tileDimension)
+    }
+}
+
+export { tileKey, colorScaleKey, tileGrid }

--- a/js/imageTileSource.js
+++ b/js/imageTileSource.js
@@ -1,0 +1,356 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 The Regents of the University of California
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import ColorScale from './colorScale.js'
+import {
+    tileKey,
+    colorScaleKey,
+    tileGrid,
+    resolveDisplayMode,
+    autoThreshold,
+    indexControlRecords,
+    paintRecords
+} from './imageTileCore.js'
+
+const DEFAULT_TILE_DIMENSION = 685
+
+/**
+ * Supplies image tiles for a contact map view. See CONTEXT.md for "image tile".
+ *
+ * One call to tilesFor absorbs display-mode dataset selection, zoom-index
+ * translation between the primary and control maps, matrix and zoom-data
+ * resolution, tile grid math, automatic color-scale computation, the tile
+ * cache, in-flight de-duplication and rasterization.
+ *
+ *   const source = new ImageTileSource({colorScale, ratioColorScale, observer})
+ *
+ *   for await (const tile of source.tilesFor({
+ *       dataset, controlDataset, state, displayMode, viewDimensions
+ *   })) {
+ *       view.paint(tile)
+ *   }
+ *
+ *   source.invalidate({thresholds: true})
+ *
+ * The source never mutates canonical state. Where the requested normalization
+ * is unavailable it renders the pass with a fallback and reports the
+ * discrepancy through the observer; deciding what to do about it belongs to
+ * whoever owns state mutation.
+ *
+ * Tiles are yielded one at a time as they resolve, so a caller painting inside
+ * the loop fills the viewport progressively rather than waiting on the slowest
+ * fetch.
+ */
+class ImageTileSource {
+
+    /**
+     * @param colorScale scale for the single-map display modes
+     * @param ratioColorScale scale for AOB / BOA
+     * @param diffColorScale scale for AMB. Currently undefined -- AMB has been
+     *        unimplemented since 2018, see issue #426. Passed through so the
+     *        behavior is unchanged rather than silently repaired here.
+     * @param createTile factory for a raster surface. Defaults to a canvas;
+     *        tests inject a stub, since the test environment has no canvas.
+     * @param observer receives colorScaleChanged, normalizationUnavailable and
+     *        loadingChanged. All optional.
+     * @param tileDimension tile edge length in bins
+     * @param cacheLimit retained tile count
+     */
+    constructor({
+                    colorScale,
+                    ratioColorScale,
+                    diffColorScale,
+                    createTile,
+                    observer = {},
+                    tileDimension = DEFAULT_TILE_DIMENSION,
+                    cacheLimit = 8      // 8 is the minimum number required to support A/B cycling
+                } = {}) {
+
+        this.colorScale = colorScale
+        this.ratioColorScale = ratioColorScale
+        this.diffColorScale = diffColorScale
+
+        this.createTile = createTile || defaultCreateTile
+        this.observer = observer
+        this.tileDimension = tileDimension
+
+        this.cache = {}
+        this.cacheKeys = []
+        this.cacheLimit = cacheLimit
+        this.thresholdCache = {}
+        this.drawsInProgress = new Set()
+    }
+
+    // -- color scale ------------------------------------------------------
+
+    getColorScale(displayMode) {
+        switch (displayMode) {
+            case 'AOB':
+            case 'BOA':
+                return this.ratioColorScale
+            case 'AMB':
+                return this.diffColorScale
+            default:
+                return this.colorScale
+        }
+    }
+
+    setColorScale(colorScale, displayMode, state) {
+        switch (displayMode) {
+            case 'AOB':
+            case 'BOA':
+                this.ratioColorScale = colorScale
+                break
+            case 'AMB':
+                this.diffColorScale = colorScale
+                break
+            default:
+                this.colorScale = colorScale
+        }
+        this.thresholdCache[colorScaleKey(state, displayMode)] = colorScale.threshold
+    }
+
+    setThreshold(threshold, displayMode, state) {
+        this.getColorScale(displayMode).setThreshold(threshold)
+        this.thresholdCache[colorScaleKey(state, displayMode)] = threshold
+        this.invalidate()
+    }
+
+    /**
+     * Discard cached tiles. Threshold caching is separate and survives by
+     * default: a pan or a color change invalidates rasters but not the computed
+     * threshold. Pass {thresholds: true} on map load, where both are stale.
+     */
+    invalidate({thresholds = false} = {}) {
+        this.cache = {}
+        this.cacheKeys = []
+        if (thresholds) {
+            this.thresholdCache = {}
+        }
+    }
+
+    // -- tiles ------------------------------------------------------------
+
+    /**
+     * Yields the image tiles covering the view, in row-major order.
+     *
+     * Each tile is {row, column, blockBinCount, binSize} plus either an `image`
+     * or `inProgress: true`. An in-progress tile is one whose raster is already
+     * being drawn by an overlapping pass; the caller decides what to show in
+     * its place.
+     *
+     * `binSize` is carried on every tile because the caller needs it to express
+     * the view's genomic extent, and it has no other route to the zoom data.
+     */
+    async* tilesFor({dataset, controlDataset, state, displayMode, viewDimensions}) {
+
+        const {ds, dsControl, zoom, controlZoom} =
+            resolveDisplayMode(dataset, controlDataset, state.zoom, displayMode)
+
+        const matrix = await ds.getMatrix(state.chr1, state.chr2)
+        const zd = matrix.getZoomDataByIndex(zoom, "BP")
+
+        let zdControl = null
+        if (dsControl) {
+            const matrixControl = await dsControl.getMatrix(state.chr1, state.chr2)
+            zdControl = matrixControl.getZoomDataByIndex(controlZoom, "BP")
+        }
+
+        const {row1, row2, col1, col2} = tileGrid(state, viewDimensions, this.tileDimension)
+
+        const normalization = this.#effectiveNormalization(ds, zd, state.normalization)
+
+        await this.#ensureColorScale(ds, zd, {row1, row2, col1, col2}, normalization, state, displayMode)
+
+        for (let row = row1; row <= row2; row++) {
+            for (let column = col1; column <= col2; column++) {
+                yield await this.#tileAt(
+                    {ds, dsControl, zd, zdControl, normalization, displayMode},
+                    row,
+                    column
+                )
+            }
+        }
+    }
+
+    /**
+     * The normalization this pass can actually render with.
+     *
+     * A vector absent at the current resolution falls back to NONE. The source
+     * reports the fallback and renders with it; it does not write state.
+     */
+    #effectiveNormalization(ds, zd, requested) {
+
+        if (requested === "NONE") return requested
+
+        if (ds.hasNormalizationVector(requested, zd.chr1.name, zd.zoom.unit, zd.zoom.binSize)) {
+            return requested
+        }
+
+        this.observer.normalizationUnavailable?.(requested, "NONE")
+        return "NONE"
+    }
+
+    /**
+     * Compute and apply the automatic color scale threshold, if needed.
+     *
+     * Ratio modes are left alone -- their scale is user-driven, not derived
+     * from the data. Otherwise the threshold is memoized per chromosome pair,
+     * zoom and normalization, so panning within a resolution does not refetch.
+     */
+    async #ensureColorScale(ds, zd, grid, normalization, state, displayMode) {
+
+        if ('AOB' === displayMode || 'BOA' === displayMode) {
+            return
+        }
+
+        const key = colorScaleKey(state, displayMode)
+
+        if (this.thresholdCache[key]) {
+            const cached = this.thresholdCache[key]
+            const changed = this.colorScale.threshold !== cached
+            this.colorScale.setThreshold(cached)
+            if (changed) {
+                this.observer.colorScaleChanged?.(this.colorScale)
+            }
+            return
+        }
+
+        this.observer.loadingChanged?.(true)
+        try {
+            const widthInBP = this.tileDimension * zd.zoom.binSize
+            const x0bp = grid.col1 * widthInBP
+            const y0bp = grid.row1 * widthInBP
+            const region1 = {
+                chr: zd.chr1.name,
+                start: x0bp,
+                end: x0bp + (grid.col2 - grid.col1 + 1) * widthInBP
+            }
+            const region2 = {
+                chr: zd.chr2.name,
+                start: y0bp,
+                end: y0bp + (grid.row2 - grid.row1 + 1) * widthInBP
+            }
+
+            const records = await ds.getContactRecords(
+                normalization, region1, region2, zd.zoom.unit, zd.zoom.binSize, true)
+
+            const threshold = autoThreshold(records, {
+                isLive: ds.isLive,
+                isWholeGenome: 0 === zd.chr1.index
+            })
+
+            if (undefined !== threshold) {
+                this.colorScale = new ColorScale(this.colorScale)
+                this.colorScale.setThreshold(threshold)
+                this.observer.colorScaleChanged?.(this.colorScale)
+                this.thresholdCache[key] = threshold
+            }
+        } finally {
+            this.observer.loadingChanged?.(false)
+        }
+    }
+
+    async #tileAt({ds, dsControl, zd, zdControl, normalization, displayMode}, row, column) {
+
+        const key = tileKey(zd, row, column, normalization, displayMode)
+        const binSize = zd.zoom.binSize
+
+        if (this.cache.hasOwnProperty(key)) {
+            return this.cache[key]
+        }
+
+        if (this.drawsInProgress.has(key)) {
+            // TODO return an image at a coarser resolution if available
+            return {row, column, blockBinCount: this.tileDimension, binSize, inProgress: true}
+        }
+
+        this.drawsInProgress.add(key)
+        this.observer.loadingChanged?.(true)
+
+        try {
+            const widthInBP = this.tileDimension * binSize
+            const x0bp = column * widthInBP
+            const y0bp = row * widthInBP
+            const region1 = {chr: zd.chr1.name, start: x0bp, end: x0bp + widthInBP}
+            const region2 = {chr: zd.chr2.name, start: y0bp, end: y0bp + widthInBP}
+
+            const records = await ds.getContactRecords(
+                normalization, region1, region2, zd.zoom.unit, binSize)
+
+            let controlRecordList
+            if (zdControl) {
+                controlRecordList = await dsControl.getContactRecords(
+                    normalization, region1, region2, zdControl.zoom.unit, zdControl.zoom.binSize)
+            }
+
+            const image = this.createTile(this.tileDimension)
+
+            if (records.length > 0) {
+                const ctx = image.getContext('2d')
+                const buf = ctx.getImageData(0, 0, image.width, image.height)
+
+                paintRecords(buf, records, indexControlRecords(controlRecordList, displayMode), {
+                    displayMode,
+                    tileDimension: this.tileDimension,
+                    sameChr: zd.chr1.index === zd.chr2.index,
+                    averageCount: zd.averageCount,
+                    ctrlAverageCount: zdControl ? zdControl.averageCount : 1,
+                    colorScale: this.colorScale,
+                    ratioColorScale: this.ratioColorScale,
+                    diffColorScale: this.diffColorScale
+                }, row, column)
+
+                ctx.putImageData(buf, 0, 0)
+            }
+
+            const tile = {row, column, blockBinCount: this.tileDimension, binSize, image}
+
+            if (this.cacheLimit > 0) {
+                if (this.cacheKeys.length > this.cacheLimit) {
+                    delete this.cache[this.cacheKeys[0]]
+                    this.cacheKeys.shift()
+                }
+                this.cache[key] = tile
+            }
+
+            return tile
+
+        } finally {
+            this.drawsInProgress.delete(key)
+            this.observer.loadingChanged?.(false)
+        }
+    }
+}
+
+function defaultCreateTile(dimension) {
+    const canvas = document.createElement('canvas')
+    canvas.width = dimension
+    canvas.height = dimension
+    return canvas
+}
+
+export {DEFAULT_TILE_DIMENSION}
+
+export default ImageTileSource

--- a/js/imageTileSource.js
+++ b/js/imageTileSource.js
@@ -183,10 +183,18 @@ class ImageTileSource {
 
         await this.#ensureColorScale(ds, zd, {row1, row2, col1, col2}, normalization, state, displayMode)
 
+        // Retain at least two screenfuls, so switching between the A and B maps
+        // finds both cached and so no pass can evict a tile it still needs. The
+        // configured limit is a floor, not a ceiling: a 1000x1000 viewport can
+        // span 9 tiles and a 1920x1080 one 12, against a default limit of 8.
+        // A configured limit of 0 disables caching outright, and stays disabled.
+        const tilesInView = (row2 - row1 + 1) * (col2 - col1 + 1)
+        const retain = 0 === this.cacheLimit ? 0 : Math.max(this.cacheLimit, tilesInView * 2)
+
         for (let row = row1; row <= row2; row++) {
             for (let column = col1; column <= col2; column++) {
                 yield await this.#tileAt(
-                    {ds, dsControl, zd, zdControl, normalization, displayMode},
+                    {ds, dsControl, zd, zdControl, normalization, displayMode, retain},
                     row,
                     column
                 )
@@ -272,7 +280,7 @@ class ImageTileSource {
         }
     }
 
-    async #tileAt({ds, dsControl, zd, zdControl, normalization, displayMode}, row, column) {
+    async #tileAt({ds, dsControl, zd, zdControl, normalization, displayMode, retain}, row, column) {
 
         const key = tileKey(zd, row, column, normalization, displayMode)
         const binSize = zd.zoom.binSize
@@ -327,12 +335,12 @@ class ImageTileSource {
 
             const tile = {row, column, blockBinCount: this.tileDimension, binSize, image}
 
-            if (this.cacheLimit > 0) {
-                if (this.cacheKeys.length > this.cacheLimit) {
-                    delete this.cache[this.cacheKeys[0]]
-                    this.cacheKeys.shift()
-                }
+            if (retain > 0) {
                 this.cache[key] = tile
+                this.cacheKeys.push(key)
+                while (this.cacheKeys.length > retain) {
+                    delete this.cache[this.cacheKeys.shift()]
+                }
             }
 
             return tile

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {tileKey, colorScaleKey, tileGrid} from '../js/imageTileCore.js'
+import {tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode} from '../js/imageTileCore.js'
 
 /**
  * Characterization tests for the pure core of the image tile source.
@@ -133,5 +133,84 @@ describe('tileGrid', () => {
         const grid = tileGrid({x: 0, y: 0, pixelSize: 1}, {width: 2000, height: 1400}, TILE)
         expect(grid.col2 - grid.col1).toBe(2)
         expect(grid.row2 - grid.row1).toBe(2)
+    })
+})
+
+/**
+ * Datasets stand in for HiCDataset. Only the two resolution-lookup methods are
+ * exercised, and both are pure lookups over a bin-size array.
+ */
+const datasetWith = (resolutions) => ({
+    bpResolutions: resolutions,
+    getBinSizeForZoomIndex: (index) => resolutions[index],
+    getZoomIndexForBinSize: (binSize) => resolutions.indexOf(binSize)
+})
+
+describe('bZoomIndex', () => {
+
+    it('matches maps by resolution, not by index', () => {
+        const a = datasetWith([1000000, 500000, 100000])
+        const b = datasetWith([500000, 100000])
+        // index 2 on A is 100kb, which is index 1 on B
+        expect(bZoomIndex(a, b, 2)).toBe(1)
+    })
+
+    it('is the identity when both maps carry the same resolutions', () => {
+        const res = [1000000, 500000, 100000]
+        expect(bZoomIndex(datasetWith(res), datasetWith(res), 1)).toBe(1)
+    })
+
+    it('throws when the zoom index is absent from the primary map', () => {
+        const a = datasetWith([1000000])
+        const b = datasetWith([1000000])
+        expect(() => bZoomIndex(a, b, 5)).toThrow(/Invalid zoom \(resolution\) index: 5/)
+    })
+
+    it('throws when the resolution is absent from the control map', () => {
+        const a = datasetWith([1000000, 25000])
+        const b = datasetWith([1000000])
+        expect(() => bZoomIndex(a, b, 1)).toThrow(/Invalid binSize for "B" map: 25000/)
+    })
+})
+
+describe('resolveDisplayMode', () => {
+
+    const a = datasetWith([1000000, 500000, 100000])
+    const b = datasetWith([500000, 100000])
+
+    it('A renders the primary map alone and translates nothing', () => {
+        expect(resolveDisplayMode(a, b, 2, 'A')).toEqual({ds: a, dsControl: null, zoom: 2, controlZoom: undefined})
+    })
+
+    it('A leaves the zoom index untouched even with no control map loaded', () => {
+        expect(resolveDisplayMode(a, null, 2, 'A')).toEqual({ds: a, dsControl: null, zoom: 2, controlZoom: undefined})
+    })
+
+    it('B renders the control map as if it were primary, at the translated index', () => {
+        expect(resolveDisplayMode(a, b, 2, 'B')).toEqual({ds: b, dsControl: null, zoom: 1, controlZoom: undefined})
+    })
+
+    it('AOB keeps A primary and translates only the control zoom', () => {
+        expect(resolveDisplayMode(a, b, 2, 'AOB')).toEqual({ds: a, dsControl: b, zoom: 2, controlZoom: 1})
+    })
+
+    it('AMB resolves identically to AOB -- they differ only in how scores combine', () => {
+        expect(resolveDisplayMode(a, b, 2, 'AMB')).toEqual(resolveDisplayMode(a, b, 2, 'AOB'))
+    })
+
+    it('BOA swaps the roles: B is primary at the translated index, A is control at the original', () => {
+        expect(resolveDisplayMode(a, b, 2, 'BOA')).toEqual({ds: b, dsControl: a, zoom: 1, controlZoom: 2})
+    })
+
+    it('BOA control zoom is the incoming index, not the translated one', () => {
+        // Guards the ordering: translating zoom before capturing controlZoom
+        // would leave both at the B index.
+        const {zoom, controlZoom} = resolveDisplayMode(a, b, 2, 'BOA')
+        expect(controlZoom).toBe(2)
+        expect(zoom).toBe(1)
+    })
+
+    it('an unrecognised display mode falls through to primary-only', () => {
+        expect(resolveDisplayMode(a, b, 2, 'nonsense')).toEqual({ds: a, dsControl: null, zoom: 2, controlZoom: undefined})
     })
 })

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {tileKey, colorScaleKey} from '../js/imageTileCore.js'
+import {tileKey, colorScaleKey, tileGrid} from '../js/imageTileCore.js'
 
 /**
  * Characterization tests for the pure core of the image tile source.
@@ -81,5 +81,57 @@ describe('colorScaleKey', () => {
 
     it('does not collide the startup fallback across display modes', () => {
         expect(colorScaleKey(undefined, 'A')).not.toBe(colorScaleKey(undefined, 'B'))
+    })
+})
+
+describe('tileGrid', () => {
+
+    const TILE = 685
+    const view = {width: 685, height: 685}
+
+    it('returns the single origin tile for a view at the origin', () => {
+        expect(tileGrid({x: 0, y: 0, pixelSize: 1}, view, TILE))
+            .toEqual({row1: 0, row2: 1, col1: 0, col2: 1})
+    })
+
+    it('is inclusive on both ends -- a view ending exactly on a boundary includes that tile', () => {
+        // 685 bins wide starting at bin 0 reaches bin 685, which is tile 1.
+        const {col1, col2} = tileGrid({x: 0, y: 0, pixelSize: 1}, view, TILE)
+        expect(col1).toBe(0)
+        expect(col2).toBe(1)
+    })
+
+    it('covers a single tile when the view sits strictly inside one', () => {
+        expect(tileGrid({x: 10, y: 10, pixelSize: 2}, {width: 400, height: 400}, TILE))
+            .toEqual({row1: 0, row2: 0, col1: 0, col2: 0})
+    })
+
+    it('advances the range as the view pans across a tile boundary', () => {
+        const before = tileGrid({x: 600, y: 0, pixelSize: 4}, {width: 200, height: 200}, TILE)
+        const after = tileGrid({x: 700, y: 0, pixelSize: 4}, {width: 200, height: 200}, TILE)
+        expect(before.col1).toBe(0)
+        expect(after.col1).toBe(1)
+    })
+
+    it('floors fractional pixelSize when deriving bin extent', () => {
+        // pixelSize 1.9 floors to 1, so the view spans 685 bins, not 360.
+        expect(tileGrid({x: 0, y: 0, pixelSize: 1.9}, view, TILE).col2).toBe(1)
+    })
+
+    it('floors pixelSize at 1 so sub-pixel resolutions do not divide by zero', () => {
+        const grid = tileGrid({x: 0, y: 0, pixelSize: 0.25}, view, TILE)
+        expect(Number.isFinite(grid.col2)).toBe(true)
+        expect(grid.col2).toBe(1)
+    })
+
+    it('derives rows from y and columns from x independently', () => {
+        expect(tileGrid({x: 0, y: 2000, pixelSize: 4}, {width: 100, height: 100}, TILE))
+            .toEqual({row1: 2, row2: 2, col1: 0, col2: 0})
+    })
+
+    it('spans multiple tiles for a large viewport at pixelSize 1', () => {
+        const grid = tileGrid({x: 0, y: 0, pixelSize: 1}, {width: 2000, height: 1400}, TILE)
+        expect(grid.col2 - grid.col1).toBe(2)
+        expect(grid.row2 - grid.row1).toBe(2)
     })
 })

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -6,7 +6,9 @@ import {
     bZoomIndex,
     resolveDisplayMode,
     computePercentile,
-    autoThreshold
+    autoThreshold,
+    indexControlRecords,
+    paintRecords
 } from '../js/imageTileCore.js'
 
 /**
@@ -291,5 +293,242 @@ describe('autoThreshold', () => {
     it('never returns a whole-genome scaled value from an empty set', () => {
         // Guards against the x4 being applied to undefined and yielding NaN.
         expect(autoThreshold([], {isLive: false, isWholeGenome: true})).toBeUndefined()
+    })
+})
+
+/**
+ * A pixel buffer shaped like ImageData. In production this comes from
+ * getImageData on a tile canvas; here it is a plain object, which is the whole
+ * point of paintRecords taking a buffer rather than a context.
+ */
+const pixelBuffer = (width, height = width) => ({
+    width,
+    height,
+    data: new Uint8ClampedArray(width * height * 4)
+})
+
+const pixelAt = (buf, x, y) => {
+    const i = (x + y * buf.width) * 4
+    return [buf.data[i], buf.data[i + 1], buf.data[i + 2], buf.data[i + 3]]
+}
+
+const BLANK = [0, 0, 0, 0]
+
+const record = (bin1, bin2, counts) => ({
+    bin1,
+    bin2,
+    counts,
+    getKey: () => `${bin1}_${bin2}`
+})
+
+// Encodes the count into the red channel so tests can tell which record
+// painted which pixel.
+const countScale = {getColor: (v) => ({red: v, green: 0, blue: 0, alpha: 255})}
+const constantScale = (red) => ({getColor: () => ({red, green: 0, blue: 0, alpha: 255})})
+
+const basePlan = (overrides = {}) => ({
+    displayMode: 'A',
+    tileDimension: 10,
+    sameChr: false,
+    averageCount: 1,
+    ctrlAverageCount: 1,
+    colorScale: countScale,
+    ratioColorScale: constantScale(50),
+    diffColorScale: constantScale(60),
+    ...overrides
+})
+
+describe('indexControlRecords', () => {
+
+    it('indexes by bin pair for the combining modes', () => {
+        const recs = [record(1, 2, 10), record(3, 4, 20)]
+        for (const mode of ['AOB', 'BOA', 'AMB']) {
+            expect(Object.keys(indexControlRecords(recs, mode))).toEqual(['1_2', '3_4'])
+        }
+    })
+
+    it('returns an empty index for single-map modes, which never consult it', () => {
+        const recs = [record(1, 2, 10)]
+        expect(indexControlRecords(recs, 'A')).toEqual({})
+        expect(indexControlRecords(recs, 'B')).toEqual({})
+    })
+
+    it('does not touch the record list for single-map modes', () => {
+        // cRecords is undefined whenever there is no control zoom data,
+        // so the guard must short-circuit before iterating.
+        expect(() => indexControlRecords(undefined, 'A')).not.toThrow()
+    })
+})
+
+describe('paintRecords', () => {
+
+    describe('single-map modes', () => {
+
+        it('places a record at its bin position relative to the tile origin', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(3, 4, 77)], {}, basePlan(), 0, 0)
+            expect(pixelAt(buf, 3, 4)).toEqual([77, 0, 0, 255])
+        })
+
+        it('subtracts the tile origin so tile (1,1) starts over at pixel 0', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(12, 13, 88)], {}, basePlan(), 1, 1)
+            expect(pixelAt(buf, 2, 3)).toEqual([88, 0, 0, 255])
+        })
+
+        it('colors by raw count in mode A', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(1, 1, 42)], {}, basePlan({displayMode: 'A'}), 0, 0)
+            expect(pixelAt(buf, 1, 1)[0]).toBe(42)
+        })
+
+        it('colors by raw count in mode B as well', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(1, 1, 42)], {}, basePlan({displayMode: 'B'}), 0, 0)
+            expect(pixelAt(buf, 1, 1)[0]).toBe(42)
+        })
+
+        it('returns the number of records painted', () => {
+            const buf = pixelBuffer(10)
+            const painted = paintRecords(buf, [record(1, 1, 1), record(2, 2, 2)], {}, basePlan(), 0, 0)
+            expect(painted).toBe(2)
+        })
+
+        it('leaves untouched pixels transparent', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(3, 4, 77)], {}, basePlan(), 0, 0)
+            expect(pixelAt(buf, 0, 0)).toEqual(BLANK)
+        })
+    })
+
+    describe('diagonal reflection', () => {
+
+        it('reflects across the diagonal on an on-diagonal intra-chromosomal tile', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(2, 5, 33)], {}, basePlan({sameChr: true}), 0, 0)
+            expect(pixelAt(buf, 2, 5)).toEqual([33, 0, 0, 255])
+            expect(pixelAt(buf, 5, 2)).toEqual([33, 0, 0, 255])
+        })
+
+        it('does not reflect on an off-diagonal tile', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(2, 15, 33)], {}, basePlan({sameChr: true}), 1, 0)
+            expect(pixelAt(buf, 2, 5)).toEqual([33, 0, 0, 255])
+            expect(pixelAt(buf, 5, 2)).toEqual(BLANK)
+        })
+
+        it('does not reflect for inter-chromosomal data, where the diagonal is meaningless', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(2, 5, 33)], {}, basePlan({sameChr: false}), 0, 0)
+            expect(pixelAt(buf, 2, 5)).toEqual([33, 0, 0, 255])
+            expect(pixelAt(buf, 5, 2)).toEqual(BLANK)
+        })
+    })
+
+    describe('transpose above the diagonal', () => {
+
+        it('does not transpose below the diagonal', () => {
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(3, 12, 55)], {}, basePlan({sameChr: true}), 1, 0)
+            expect(pixelAt(buf, 3, 2)).toEqual([55, 0, 0, 255])
+        })
+
+        it('transposes tiles above the diagonal, mirroring their below-diagonal twin', () => {
+            // Intra-chromosomal data is stored lower-diagonal, so an above-diagonal
+            // query returns the mirrored block: bins arrive in row/column order
+            // rather than column/row. The tile origins swap to match, then x and y
+            // swap back. Net effect is that tile (0,1) mirrors tile (1,0).
+            const below = pixelBuffer(10)
+            const above = pixelBuffer(10)
+
+            paintRecords(below, [record(3, 12, 55)], {}, basePlan({sameChr: true}), 1, 0)
+            paintRecords(above, [record(3, 12, 55)], {}, basePlan({sameChr: true}), 0, 1)
+
+            expect(pixelAt(below, 3, 2)).toEqual([55, 0, 0, 255])
+            expect(pixelAt(above, 2, 3)).toEqual([55, 0, 0, 255])
+            expect(pixelAt(above, 3, 2)).toEqual(BLANK)
+        })
+
+        it('does not transpose inter-chromosomal tiles above the diagonal', () => {
+            // transpose is gated on sameChr; chr1 != chr2 has no symmetry to exploit.
+            const buf = pixelBuffer(10)
+            paintRecords(buf, [record(12, 3, 55)], {}, basePlan({sameChr: false}), 0, 1)
+            expect(pixelAt(buf, 2, 3)).toEqual([55, 0, 0, 255])
+        })
+    })
+
+    describe('AOB / BOA ratio mode', () => {
+
+        const plan = basePlan({
+            displayMode: 'AOB',
+            averageCount: 2,
+            ctrlAverageCount: 4,
+            ratioColorScale: countScale     // surface the score in the red channel
+        })
+
+        it('scores the ratio of normalized counts', () => {
+            const buf = pixelBuffer(10)
+            const controls = indexControlRecords([record(1, 1, 8)], 'AOB')
+            paintRecords(buf, [record(1, 1, 10)], controls, plan, 0, 0)
+            // (10 / 2) / (8 / 4) = 2.5
+            expect(pixelAt(buf, 1, 1)[0]).toBe(2.5 | 0)
+        })
+
+        it('skips records with no matching control record', () => {
+            const buf = pixelBuffer(10)
+            const painted = paintRecords(buf, [record(1, 1, 10)], {}, plan, 0, 0)
+            expect(painted).toBe(0)
+            expect(pixelAt(buf, 1, 1)).toEqual(BLANK)
+        })
+
+        it('paints only the records that do match', () => {
+            const buf = pixelBuffer(10)
+            const controls = indexControlRecords([record(1, 1, 8)], 'AOB')
+            const painted = paintRecords(buf, [record(1, 1, 10), record(2, 2, 10)], controls, plan, 0, 0)
+            expect(painted).toBe(1)
+            expect(pixelAt(buf, 2, 2)).toEqual(BLANK)
+        })
+
+        it('BOA uses the same scoring as AOB', () => {
+            const bufA = pixelBuffer(10)
+            const bufB = pixelBuffer(10)
+            const controls = indexControlRecords([record(1, 1, 8)], 'AOB')
+            paintRecords(bufA, [record(1, 1, 10)], controls, plan, 0, 0)
+            paintRecords(bufB, [record(1, 1, 10)], controls, {...plan, displayMode: 'BOA'}, 0, 0)
+            expect(pixelAt(bufA, 1, 1)).toEqual(pixelAt(bufB, 1, 1))
+        })
+    })
+
+    describe('AMB difference mode', () => {
+
+        const plan = basePlan({
+            displayMode: 'AMB',
+            averageCount: 2,
+            ctrlAverageCount: 4,
+            diffColorScale: countScale
+        })
+
+        it('scores the difference of normalized counts, scaled by the mean average', () => {
+            const buf = pixelBuffer(10)
+            const controls = indexControlRecords([record(1, 1, 8)], 'AMB')
+            paintRecords(buf, [record(1, 1, 10)], controls, plan, 0, 0)
+            // ((2 + 4) / 2) * ((10 / 2) - (8 / 4)) = 3 * 3 = 9
+            expect(pixelAt(buf, 1, 1)[0]).toBe(9)
+        })
+
+        it('skips records with no matching control record', () => {
+            const buf = pixelBuffer(10)
+            expect(paintRecords(buf, [record(1, 1, 10)], {}, plan, 0, 0)).toBe(0)
+        })
+
+        it('produces a different score from AOB for the same inputs', () => {
+            const bufRatio = pixelBuffer(10)
+            const bufDiff = pixelBuffer(10)
+            const controls = indexControlRecords([record(1, 1, 8)], 'AMB')
+            paintRecords(bufRatio, [record(1, 1, 10)], controls,
+                {...plan, displayMode: 'AOB', ratioColorScale: countScale}, 0, 0)
+            paintRecords(bufDiff, [record(1, 1, 10)], controls, plan, 0, 0)
+            expect(pixelAt(bufRatio, 1, 1)).not.toEqual(pixelAt(bufDiff, 1, 1))
+        })
     })
 })

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -1,0 +1,85 @@
+import {describe, it, expect} from 'vitest'
+import {tileKey, colorScaleKey} from '../js/imageTileCore.js'
+
+/**
+ * Characterization tests for the pure core of the image tile source.
+ *
+ * These lock in behavior as it exists today, before the pipeline is lifted out
+ * of ContactMatrixView. See issue #428.
+ */
+
+const zoomData = ({chr1 = 'chr1', chr2 = 'chr1', binSize = 5000, unit = 'BP'} = {}) => ({
+    chr1: {name: chr1},
+    chr2: {name: chr2},
+    zoom: {binSize, unit}
+})
+
+describe('tileKey', () => {
+
+    it('joins chromosome pair, resolution, unit, grid position, normalization and display mode', () => {
+        const key = tileKey(zoomData(), 3, 7, 'KR', 'A')
+        expect(key).toBe('chr1_chr1_5000_BP_3_7_KR_A')
+    })
+
+    it('distinguishes tiles differing only by grid position', () => {
+        const zd = zoomData()
+        expect(tileKey(zd, 0, 1, 'NONE', 'A')).not.toBe(tileKey(zd, 1, 0, 'NONE', 'A'))
+    })
+
+    it('distinguishes tiles differing only by normalization', () => {
+        const zd = zoomData()
+        expect(tileKey(zd, 0, 0, 'NONE', 'A')).not.toBe(tileKey(zd, 0, 0, 'KR', 'A'))
+    })
+
+    it('distinguishes tiles differing only by display mode', () => {
+        const zd = zoomData()
+        expect(tileKey(zd, 0, 0, 'NONE', 'A')).not.toBe(tileKey(zd, 0, 0, 'B', 'NONE'))
+    })
+
+    it('distinguishes tiles differing only by resolution', () => {
+        expect(tileKey(zoomData({binSize: 5000}), 0, 0, 'NONE', 'A'))
+            .not.toBe(tileKey(zoomData({binSize: 10000}), 0, 0, 'NONE', 'A'))
+    })
+
+    it('distinguishes inter-chromosomal tiles by axis order', () => {
+        expect(tileKey(zoomData({chr1: 'chr1', chr2: 'chr2'}), 0, 0, 'NONE', 'A'))
+            .not.toBe(tileKey(zoomData({chr1: 'chr2', chr2: 'chr1'}), 0, 0, 'NONE', 'A'))
+    })
+
+    it('ignores pan position and pixel size -- they affect placement, not content', () => {
+        // tileKey takes no x/y/pixelSize by design; this documents the omission.
+        const zd = zoomData()
+        expect(tileKey(zd, 2, 2, 'NONE', 'A')).toBe(tileKey(zd, 2, 2, 'NONE', 'A'))
+    })
+})
+
+describe('colorScaleKey', () => {
+
+    const state = {chr1: 1, chr2: 1, zoom: 4, normalization: 'KR'}
+
+    it('joins chromosome pair, zoom index, normalization and display mode', () => {
+        expect(colorScaleKey(state, 'A')).toBe('1_1_4_KR_A')
+    })
+
+    it('is coarser than tileKey -- shared across every tile in the view', () => {
+        expect(colorScaleKey(state, 'A')).not.toContain('BP')
+        expect(colorScaleKey(state, 'A')).not.toContain('5000')
+    })
+
+    it('distinguishes states differing only by zoom index', () => {
+        expect(colorScaleKey({...state, zoom: 4}, 'A')).not.toBe(colorScaleKey({...state, zoom: 5}, 'A'))
+    })
+
+    it('distinguishes states differing only by display mode', () => {
+        expect(colorScaleKey(state, 'A')).not.toBe(colorScaleKey(state, 'AOB'))
+    })
+
+    it('falls back to a display-mode-scoped key when state is absent during startup', () => {
+        expect(colorScaleKey(undefined, 'A')).toBe('unknown_A')
+        expect(colorScaleKey(null, 'AOB')).toBe('unknown_AOB')
+    })
+
+    it('does not collide the startup fallback across display modes', () => {
+        expect(colorScaleKey(undefined, 'A')).not.toBe(colorScaleKey(undefined, 'B'))
+    })
+})

--- a/test/testImageTileCore.js
+++ b/test/testImageTileCore.js
@@ -1,5 +1,13 @@
 import {describe, it, expect} from 'vitest'
-import {tileKey, colorScaleKey, tileGrid, bZoomIndex, resolveDisplayMode} from '../js/imageTileCore.js'
+import {
+    tileKey,
+    colorScaleKey,
+    tileGrid,
+    bZoomIndex,
+    resolveDisplayMode,
+    computePercentile,
+    autoThreshold
+} from '../js/imageTileCore.js'
 
 /**
  * Characterization tests for the pure core of the image tile source.
@@ -212,5 +220,76 @@ describe('resolveDisplayMode', () => {
 
     it('an unrecognised display mode falls through to primary-only', () => {
         expect(resolveDisplayMode(a, b, 2, 'nonsense')).toEqual({ds: a, dsControl: null, zoom: 2, controlZoom: undefined})
+    })
+})
+
+const recordsWithCounts = (counts) => counts.map(c => ({counts: c}))
+
+describe('computePercentile', () => {
+
+    it('returns the value at the p-th percentile of sorted counts', () => {
+        const records = recordsWithCounts([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        expect(computePercentile(records, 50)).toBe(6)
+    })
+
+    it('sorts numerically, not lexicographically', () => {
+        // A default Array.sort would order these as 10, 100, 9, 90.
+        const records = recordsWithCounts([100, 9, 90, 10])
+        expect(computePercentile(records, 0)).toBe(9)
+    })
+
+    it('is independent of input order', () => {
+        const ascending = recordsWithCounts([1, 2, 3, 4])
+        const shuffled = recordsWithCounts([3, 1, 4, 2])
+        expect(computePercentile(shuffled, 50)).toBe(computePercentile(ascending, 50))
+    })
+
+    it('returns undefined for no records', () => {
+        expect(computePercentile([], 95)).toBeUndefined()
+    })
+
+    it('returns undefined at the 100th percentile -- the index lands past the end', () => {
+        expect(computePercentile(recordsWithCounts([1, 2, 3]), 100)).toBeUndefined()
+    })
+})
+
+describe('autoThreshold', () => {
+
+    // 100 records with counts 1..100. The 95th percentile lands on 96,
+    // the 75th on 76.
+    const hicRecords = recordsWithCounts(Array.from({length: 100}, (_, i) => i + 1))
+
+    it('uses the 95th percentile for .hic maps', () => {
+        expect(autoThreshold(hicRecords, {isLive: false, isWholeGenome: false})).toBe(96)
+    })
+
+    it('scales x4 at whole-genome view for .hic maps', () => {
+        expect(autoThreshold(hicRecords, {isLive: false, isWholeGenome: true})).toBe(384)
+    })
+
+    it('uses the 75th percentile for live maps', () => {
+        const frequencies = recordsWithCounts(Array.from({length: 100}, (_, i) => (i + 1) / 1000))
+        expect(autoThreshold(frequencies, {isLive: true, isWholeGenome: false})).toBeCloseTo(0.076)
+    })
+
+    it('clamps live maps to the frequency ceiling of 1', () => {
+        const frequencies = recordsWithCounts([0.5, 0.9, 1, 1, 1, 1])
+        expect(autoThreshold(frequencies, {isLive: true, isWholeGenome: false})).toBe(1)
+    })
+
+    it('does not apply the whole-genome x4 to live maps -- it would overshoot the ceiling', () => {
+        const frequencies = recordsWithCounts(Array.from({length: 100}, (_, i) => (i + 1) / 1000))
+        expect(autoThreshold(frequencies, {isLive: true, isWholeGenome: true}))
+            .toBe(autoThreshold(frequencies, {isLive: true, isWholeGenome: false}))
+    })
+
+    it('returns undefined when all blocks are empty', () => {
+        expect(autoThreshold([], {isLive: false, isWholeGenome: false})).toBeUndefined()
+        expect(autoThreshold([], {isLive: true, isWholeGenome: true})).toBeUndefined()
+    })
+
+    it('never returns a whole-genome scaled value from an empty set', () => {
+        // Guards against the x4 being applied to undefined and yielding NaN.
+        expect(autoThreshold([], {isLive: false, isWholeGenome: true})).toBeUndefined()
     })
 })

--- a/test/testImageTileSource.js
+++ b/test/testImageTileSource.js
@@ -1,0 +1,420 @@
+import {describe, it, expect} from 'vitest'
+import ImageTileSource from '../js/imageTileSource.js'
+
+/**
+ * ImageTileSource is exercised end to end with plain-object fakes. Nothing here
+ * needs a browser, a canvas, a network or a HICBrowser -- which is the point of
+ * the lift. See issue #428.
+ */
+
+const TILE = 10
+
+// -- fakes ----------------------------------------------------------------
+
+const record = (bin1, bin2, counts) => ({
+    bin1, bin2, counts,
+    getKey: () => `${bin1}_${bin2}`
+})
+
+/**
+ * Stands in for a canvas. Records every getImageData/putImageData round trip so
+ * tests can read the pixels the source produced.
+ */
+const stubTile = (dimension) => {
+    const buf = {
+        width: dimension,
+        height: dimension,
+        data: new Uint8ClampedArray(dimension * dimension * 4)
+    }
+    return {
+        width: dimension,
+        height: dimension,
+        buf,
+        getContext: () => ({
+            getImageData: () => buf,
+            putImageData: () => { /* buffer is already the live one */ }
+        })
+    }
+}
+
+const zoomData = ({binSize = 1000, unit = 'BP', chr1Index = 1, chr2Index = 1, averageCount = 1} = {}) => ({
+    chr1: {name: 'chr1', index: chr1Index},
+    chr2: {name: chr1Index === chr2Index ? 'chr1' : 'chr2', index: chr2Index},
+    zoom: {binSize, unit},
+    averageCount
+})
+
+/**
+ * Stands in for HiCDataset. `records` is consulted for every getContactRecords
+ * call; `calls` records the arguments so tests can assert on fetch behavior.
+ */
+const dataset = ({
+                     records = [],
+                     resolutions = [1000],
+                     normalizations = ['NONE', 'KR'],
+                     isLive = false,
+                     zd = zoomData()
+                 } = {}) => {
+    const calls = []
+    return {
+        isLive,
+        calls,
+        bpResolutions: resolutions,
+        getBinSizeForZoomIndex: (i) => resolutions[i],
+        getZoomIndexForBinSize: (b) => resolutions.indexOf(b),
+        hasNormalizationVector: (norm) => normalizations.includes(norm),
+        getMatrix: async () => ({getZoomDataByIndex: () => zd}),
+        getContactRecords: async (norm, r1, r2, unit, binSize, forScale) => {
+            calls.push({norm, r1, r2, unit, binSize, forScale: !!forScale})
+            return records
+        }
+    }
+}
+
+/**
+ * Stands in for ColorScale. Carries r/g/b because the automatic scale path
+ * replaces the scale with `new ColorScale(previous)`, which copies those
+ * fields -- a fake without them yields undefined colour components.
+ */
+const scale = (red = 1) => ({
+    threshold: 100,
+    r: red, g: 0, b: 0,
+    setThreshold(t) { this.threshold = t },
+    getColor: () => ({red, green: 0, blue: 0, alpha: 255})
+})
+
+// The source issues two kinds of fetch: one scale-only probe per threshold
+// computation, and one per uncached tile. Most assertions care about the tiles.
+const tileFetches = (ds) => ds.calls.filter(c => !c.forScale).length
+const scaleFetches = (ds) => ds.calls.filter(c => c.forScale).length
+
+const state = (over = {}) => ({
+    chr1: 1, chr2: 1, x: 0, y: 0, zoom: 0, pixelSize: 1, normalization: 'NONE',
+    ...over
+})
+
+const request = (over = {}) => ({
+    dataset: dataset(),
+    controlDataset: null,
+    state: state(),
+    displayMode: 'A',
+    viewDimensions: {width: TILE, height: TILE},
+    ...over
+})
+
+const makeSource = (over = {}) => new ImageTileSource({
+    colorScale: scale(),
+    ratioColorScale: scale(2),
+    createTile: stubTile,
+    tileDimension: TILE,
+    ...over
+})
+
+const collect = async (iterable) => {
+    const out = []
+    for await (const item of iterable) out.push(item)
+    return out
+}
+
+const recordingObserver = () => {
+    const seen = {scales: [], fallbacks: [], loading: []}
+    return {
+        seen,
+        colorScaleChanged: (s) => seen.scales.push(s),
+        normalizationUnavailable: (req, eff) => seen.fallbacks.push([req, eff]),
+        loadingChanged: (b) => seen.loading.push(b)
+    }
+}
+
+// -- tests ----------------------------------------------------------------
+
+describe('ImageTileSource.tilesFor', () => {
+
+    it('yields one tile per grid cell, row-major', async () => {
+        const tiles = await collect(makeSource().tilesFor(request()))
+        expect(tiles.map(t => [t.row, t.column])).toEqual([[0, 0], [0, 1], [1, 0], [1, 1]])
+    })
+
+    it('yields progressively rather than resolving everything first', async () => {
+        // If the generator gathered all tiles before yielding, the dataset would
+        // show 4 fetches before the first tile arrived.
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const it = makeSource().tilesFor(request({dataset: ds}))
+
+        await it.next()
+        const afterFirst = tileFetches(ds)
+        await collect(it)
+
+        expect(afterFirst).toBe(1)
+        expect(tileFetches(ds)).toBe(4)
+    })
+
+    it('carries binSize on every tile so the caller can express genomic extent', async () => {
+        const ds = dataset({zd: zoomData({binSize: 25000})})
+        const tiles = await collect(makeSource().tilesFor(request({dataset: ds})))
+        expect(tiles.every(t => t.binSize === 25000)).toBe(true)
+    })
+
+    it('rasterizes records into the tile it was handed', async () => {
+        const ds = dataset({records: [record(3, 4, 50)]})
+        const tiles = await collect(makeSource({colorScale: scale(99)}).tilesFor(request({dataset: ds})))
+
+        const origin = tiles.find(t => t.row === 0 && t.column === 0)
+        const i = (3 + 4 * TILE) * 4
+        expect([origin.image.buf.data[i], origin.image.buf.data[i + 3]]).toEqual([99, 255])
+    })
+
+    it('does not request a raster context when there are no records', async () => {
+        // Guards the records.length > 0 branch: an empty tile stays blank
+        // rather than round-tripping through getImageData.
+        const tiles = await collect(makeSource().tilesFor(request()))
+        expect(tiles.every(t => t.image.buf.data.every(byte => byte === 0))).toBe(true)
+    })
+})
+
+describe('ImageTileSource caching', () => {
+
+    it('serves a repeated pass from cache without refetching', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        const afterFirstPass = ds.calls.length
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(ds.calls.length).toBe(afterFirstPass)
+    })
+
+    it('reuses tiles when only pixelSize changes -- scaling happens at paint time', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        const afterFirst = tileFetches(ds)
+        await collect(source.tilesFor(request({dataset: ds, state: state({pixelSize: 1})})))
+
+        expect(tileFetches(ds)).toBe(afterFirst)
+    })
+
+    it('returns the identical tile object on a cache hit', async () => {
+        const source = makeSource()
+        const first = await collect(source.tilesFor(request()))
+        const second = await collect(source.tilesFor(request()))
+        expect(second[0]).toBe(first[0])
+    })
+
+    it('refetches after invalidate', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        source.invalidate()
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(tileFetches(ds)).toBe(8)
+        expect(scaleFetches(ds)).toBe(1)    // thresholds survive invalidate()
+    })
+
+    it('keys tiles by normalization, so switching normalization misses the cache', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        await collect(source.tilesFor(request({dataset: ds, state: state({normalization: 'KR'})})))
+
+        expect(tileFetches(ds)).toBe(8)
+    })
+
+    it('does not key tiles by pan position -- panning within a tile reuses it', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        const afterFirst = ds.calls.length
+        // x moves but stays inside tile column 0
+        await collect(source.tilesFor(request({dataset: ds, state: state({x: 2})})))
+
+        expect(ds.calls.length).toBe(afterFirst)
+    })
+})
+
+describe('ImageTileSource normalization fallback', () => {
+
+    it('renders with the requested normalization when it is available', async () => {
+        const observer = recordingObserver()
+        const ds = dataset({normalizations: ['NONE', 'KR']})
+        await collect(makeSource({observer}).tilesFor(
+            request({dataset: ds, state: state({normalization: 'KR'})})))
+
+        expect(observer.seen.fallbacks).toEqual([])
+        expect(ds.calls.every(c => c.norm === 'KR')).toBe(true)
+    })
+
+    it('falls back to NONE and reports when the vector is unavailable', async () => {
+        const observer = recordingObserver()
+        const ds = dataset({normalizations: ['NONE']})
+        await collect(makeSource({observer}).tilesFor(
+            request({dataset: ds, state: state({normalization: 'KR'})})))
+
+        expect(observer.seen.fallbacks).toEqual([['KR', 'NONE']])
+        expect(ds.calls.every(c => c.norm === 'NONE')).toBe(true)
+    })
+
+    it('never mutates canonical state', async () => {
+        const s = state({normalization: 'KR'})
+        await collect(makeSource().tilesFor(
+            request({dataset: dataset({normalizations: ['NONE']}), state: s})))
+
+        expect(s.normalization).toBe('KR')
+    })
+
+    it('does not consult the dataset when normalization is already NONE', async () => {
+        let asked = false
+        const ds = dataset()
+        ds.hasNormalizationVector = () => { asked = true; return true }
+        await collect(makeSource().tilesFor(request({dataset: ds})))
+        expect(asked).toBe(false)
+    })
+})
+
+describe('ImageTileSource automatic color scale', () => {
+
+    const manyRecords = Array.from({length: 100}, (_, i) => record(0, 0, i + 1))
+
+    it('computes a threshold from a dedicated scale-only fetch', async () => {
+        const observer = recordingObserver()
+        const ds = dataset({records: manyRecords})
+        await collect(makeSource({observer}).tilesFor(request({dataset: ds})))
+
+        expect(ds.calls.filter(c => c.forScale).length).toBe(1)
+        expect(observer.seen.scales.length).toBe(1)
+        expect(observer.seen.scales[0].threshold).toBe(96)   // 95th percentile
+    })
+
+    it('memoizes the threshold across passes at the same zoom', async () => {
+        const ds = dataset({records: manyRecords})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        source.invalidate()                       // drop rasters, keep thresholds
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(ds.calls.filter(c => c.forScale).length).toBe(1)
+    })
+
+    it('recomputes after invalidate({thresholds: true})', async () => {
+        const ds = dataset({records: manyRecords})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        source.invalidate({thresholds: true})
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(ds.calls.filter(c => c.forScale).length).toBe(2)
+    })
+
+    it('leaves ratio modes alone -- their scale is user-driven', async () => {
+        const observer = recordingObserver()
+        const control = dataset({records: manyRecords})
+        const ds = dataset({records: manyRecords})
+
+        await collect(makeSource({observer}).tilesFor(
+            request({dataset: ds, controlDataset: control, displayMode: 'AOB'})))
+
+        expect(ds.calls.filter(c => c.forScale).length).toBe(0)
+        expect(observer.seen.scales).toEqual([])
+    })
+
+    it('applies the live-map heuristic when the dataset is live', async () => {
+        const observer = recordingObserver()
+        const frequencies = Array.from({length: 100}, (_, i) => record(0, 0, (i + 1) / 1000))
+        await collect(makeSource({observer}).tilesFor(
+            request({dataset: dataset({records: frequencies, isLive: true})})))
+
+        // 75th percentile of the frequencies, not the 95th
+        expect(observer.seen.scales[0].threshold).toBeCloseTo(0.076)
+    })
+
+    it('emits no color scale change when no threshold can be computed', async () => {
+        const observer = recordingObserver()
+        await collect(makeSource({observer}).tilesFor(request()))
+        expect(observer.seen.scales).toEqual([])
+    })
+})
+
+describe('ImageTileSource loading signal', () => {
+
+    it('is balanced across a pass', async () => {
+        const observer = recordingObserver()
+        await collect(makeSource({observer}).tilesFor(
+            request({dataset: dataset({records: [record(0, 0, 5)]})})))
+
+        const opens = observer.seen.loading.filter(Boolean).length
+        const closes = observer.seen.loading.filter(b => !b).length
+        expect(opens).toBe(closes)
+    })
+
+    it('stays quiet on a fully cached pass', async () => {
+        // Needs records: with none, autoThreshold yields undefined, nothing is
+        // memoized, and every pass re-probes for a scale.
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource()
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        const observer = recordingObserver()
+        source.observer = observer
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(observer.seen.loading).toEqual([])
+    })
+
+    it('re-probes for a scale on every pass when the region is empty', async () => {
+        // Documents a pre-existing quirk carried over from checkColorScale: an
+        // uncomputable threshold is never memoized, so an empty region pays for
+        // a scale-only fetch on every repaint.
+        const ds = dataset({records: []})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(scaleFetches(ds)).toBe(2)
+    })
+})
+
+describe('ImageTileSource display modes', () => {
+
+    it('renders the control map in mode B', async () => {
+        const primary = dataset({records: [record(0, 0, 5)]})
+        const control = dataset({records: [record(0, 0, 9)]})
+
+        await collect(makeSource().tilesFor(
+            request({dataset: primary, controlDataset: control, displayMode: 'B'})))
+
+        expect(primary.calls.length).toBe(0)
+        expect(control.calls.length).toBeGreaterThan(0)
+    })
+
+    it('fetches from both maps in AOB', async () => {
+        const primary = dataset({records: [record(0, 0, 5)]})
+        const control = dataset({records: [record(0, 0, 9)]})
+
+        await collect(makeSource().tilesFor(
+            request({dataset: primary, controlDataset: control, displayMode: 'AOB'})))
+
+        expect(primary.calls.length).toBeGreaterThan(0)
+        expect(control.calls.length).toBeGreaterThan(0)
+    })
+
+    it('keys tiles by display mode', async () => {
+        const primary = dataset({records: [record(0, 0, 5)]})
+        const control = dataset({records: [record(0, 0, 9)]})
+        const source = makeSource()
+
+        await collect(source.tilesFor(request({dataset: primary, controlDataset: control, displayMode: 'A'})))
+        const afterA = primary.calls.length
+        await collect(source.tilesFor(request({dataset: primary, controlDataset: control, displayMode: 'AOB'})))
+
+        expect(primary.calls.length).toBeGreaterThan(afterA)
+    })
+})

--- a/test/testImageTileSource.js
+++ b/test/testImageTileSource.js
@@ -225,6 +225,84 @@ describe('ImageTileSource caching', () => {
         expect(tileFetches(ds)).toBe(8)
     })
 
+    it('evicts the oldest tile once the retained count is exceeded', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        // One tile per pass, retaining two.
+        const source = makeSource({cacheLimit: 2})
+        const oneTile = {width: 1, height: 1}
+
+        for (const x of [0, TILE, TILE * 2]) {
+            await collect(source.tilesFor(request({
+                dataset: ds, state: state({x}), viewDimensions: oneTile
+            })))
+        }
+
+        expect(source.cacheKeys.length).toBe(2)
+        expect(Object.keys(source.cache).length).toBe(2)
+    })
+
+    it('keeps cache and cacheKeys in step', async () => {
+        // The original eviction shifted cacheKeys but never pushed to it, so the
+        // two structures diverged and the cache grew without bound.
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource({cacheLimit: 2})
+        const oneTile = {width: 1, height: 1}
+
+        for (const x of [0, TILE, TILE * 2, TILE * 3]) {
+            await collect(source.tilesFor(request({
+                dataset: ds, state: state({x}), viewDimensions: oneTile
+            })))
+        }
+
+        expect(source.cacheKeys.length).toBe(Object.keys(source.cache).length)
+        expect(source.cacheKeys.every(k => k in source.cache)).toBe(true)
+    })
+
+    it('never evicts a tile the current view still needs', async () => {
+        // Regression guard. A 1000x1000 viewport can span 9 tiles and a
+        // 1920x1080 one 12, against a default limit of 8 -- honouring the limit
+        // literally would evict tiles mid-pass and refetch them every repaint.
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource({cacheLimit: 2})
+        const fourTiles = {width: TILE, height: TILE}   // 2x2 grid
+
+        await collect(source.tilesFor(request({dataset: ds, viewDimensions: fourTiles})))
+        const afterFirst = tileFetches(ds)
+        await collect(source.tilesFor(request({dataset: ds, viewDimensions: fourTiles})))
+
+        expect(afterFirst).toBe(4)
+        expect(tileFetches(ds)).toBe(4)      // second pass entirely cached
+    })
+
+    it('caches nothing when the limit is zero', async () => {
+        const ds = dataset({records: [record(0, 0, 5)]})
+        const source = makeSource({cacheLimit: 0})
+
+        await collect(source.tilesFor(request({dataset: ds})))
+        await collect(source.tilesFor(request({dataset: ds})))
+
+        expect(source.cacheKeys.length).toBe(0)
+        expect(tileFetches(ds)).toBe(8)      // every pass refetches
+    })
+
+    it('retains two screenfuls, so A/B cycling stays cached', async () => {
+        const primary = dataset({records: [record(0, 0, 5)]})
+        const control = dataset({records: [record(0, 0, 9)]})
+        const source = makeSource({cacheLimit: 2})
+        const fourTiles = {width: TILE, height: TILE}
+
+        const pass = (displayMode) => collect(source.tilesFor(request({
+            dataset: primary, controlDataset: control, displayMode, viewDimensions: fourTiles
+        })))
+
+        await pass('A')
+        await pass('B')
+        const afterCycle = primary.calls.length + control.calls.length
+        await pass('A')                      // back to A -- should be cached
+
+        expect(primary.calls.length + control.calls.length).toBe(afterCycle)
+    })
+
     it('does not key tiles by pan position -- panning within a tile reuses it', async () => {
         const ds = dataset({records: [record(0, 0, 5)]})
         const source = makeSource()


### PR DESCRIPTION
Closes #428. Fixes #425.

`contactMatrixView.js` **1116 → 761 lines**. Tests **65 → 164** — the first rendering coverage in this repo.

## What changed

The pure logic in the render path — tile key derivation, grid math, B-map zoom translation, the auto colour-scale heuristics, rasterization — was reachable only through a live `HICBrowser` and a real canvas, so none of it was tested. It now sits behind one interface:

```js
new ImageTileSource({colorScale, ratioColorScale, createTile, observer})

for await (const tile of source.tilesFor({
    dataset, controlDataset, state, displayMode, viewDimensions
})) { view.paintTile(tile) }

source.invalidate({thresholds})
```

One call absorbs display-mode dataset selection, zoom-index translation, matrix and zoom-data resolution, tile grid math, auto colour scale, the cache, in-flight de-duplication and rasterization. The view keeps canvas sizing, blitting, the spinner, gestures and 2D overlays.

## Reviewing this

Four phases, thirteen commits, each independently revertable. Reading them in order is much easier than reading the diff.

| Commits | Phase |
|---|---|
| `654d8b1` `43df238` `6be7f9d` `dcd2398` `3d6e11c` | 1 — extract six pure functions **in place**, structure unchanged, one test file each |
| `0c2886f` | 2 — assemble `ImageTileSource` from them |
| `8f5eb6b` | 3 — view consumes it; `getImageTile` and `checkColorScale` deleted |
| `878af70` | 4 — fix cache eviction |

Phase 1 is deliberately boring: it breaks the catch-22 where the module could not be characterized before the refactor because it was untestable in its existing shape.

## Design decisions worth a look

- **Async generator, not an array.** Preserves progressive painting. An array return would blank the viewport until the slowest fetch resolved.
- **Pure `paintRecords(buf, ...)` core plus an injected `createTile`.** Tests run in bare Node with no canvas, so rasterization is testable only if the pixel buffer is a plain object.
- **A state snapshot for tile content, live state for placement.** Content must be stable or a mid-pass change caches under the wrong key; placement must be live or tiles resolving late during a pan land where the view *was*.
- **The source never writes canonical state.** An unavailable normalization is reported through the observer; the correction is applied by the observer wired in `browserUIManager`.
- **The canvas clears on the first yielded tile**, not before iterating — the source may fetch for the colour scale before yielding, and clearing up front would flicker on every pass.

## Two deliberate behaviour changes

Everything else is behaviour-preserving.

**1. The loading signal is balanced.** `checkColorScale` called `stopSpinner()` in a `finally` with no matching `startSpinner()`, driving `spinnerCount` negative on every threshold computation. Porting that asymmetry through an observer contract would have been incoherent. Resolves item 2 of #427.

**2. The cache limit is now a floor, not a ceiling.** Eviction never worked — `cacheKeys` was `shift()`ed but never pushed to — so the cache grew without bound at ~1.9 MB per tile. Adding the missing push alone would have traded a leak for thrashing: the declared limit of 8 dates from a 640×640 viewport (4 tiles), while 1000×1000 spans 9 and 1920×1080 spans 12. Now retains `max(cacheLimit, tilesInView * 2)`, preserving the original "two screenfuls so A/B cycling hits" intent. Bounded at roughly 15/34/45 MB for those viewports.

## Also in this branch

Not strictly refactor work, and separable if you would rather land them independently:

- **`5d1147f`** — one-line `Alert` import fixing #425. Also the root cause of **#372**, open since 2022: the missing import meant an unavailable normalization threw `ReferenceError`, so the user got neither the alert nor the fallback.
- **`e4b7bfc` `8346dd0` `16c04f6`** — repairs to three `dev/` harnesses. Required as instrumentation: most fixtures return 403/405 to a browser because their hosts gate on `User-Agent`, which the Fetch spec forbids browsers from setting. See #429 and aidenlab/hic-straw#46.
- **`ebebefa`** — `CONTEXT.md`, created lazily once *tile* needed disambiguating; it meant three unrelated things across the render path.

## Verification

164 unit tests plus a manual pass over `dev/big_viewport.html`, `generic-test-harness.html` (both `config_smoke` and `config_ab_compare`), `juicebox-normalization-warning.html` and `bug-daphne-qin-vanishing-2d-annotation.html`.

**The gap to know about:** nothing tests the seam between `ImageTileSource` and `ContactMatrixView`. The tests cover the source; the view's wiring is verified manually only, because the view is DOM-bound. That is inherent to where the seam went, but it means the harness runs are load-bearing.

## Deferred

#426 (AMB unimplemented — needs a signed difference scale, dead since 2018), #430 (`render2DTracks` passes `chr1` twice), #431 (`zoomIn` ignores its arguments), #432 (colour-scale widget staleness), #429 (examples URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)