### PR TITLE
Report bot-protection blocks in plain language (#441, #442)

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -155,6 +155,7 @@
             { name: 'Bug: Daphne Qin Vanishing 2D Annotation', path: 'dev/bug-daphne-qin-vanishing-2d-annotation.html' },
             { name: 'DAT Sequence Gene Track', path: 'dev/dat-sequence-gene-track.html' },
             { name: 'Generic Test Harness', path: 'dev/generic-test-harness.html' },
+            { name: 'Issue 49: hic-straw Transport Extension Points', path: 'dev/issue-49-hic-straw-transport-extension-points.html' },
             { name: 'jQuery Cleanse', path: 'dev/jquery-cleanse.html' },
             { name: 'Juicebox Normalization Warning', path: 'dev/juicebox-normalization-warning.html' },
             { name: 'Load and Reset', path: 'dev/load-and-reset.html' },

--- a/dev/issue-49-hic-straw-transport-extension-points.html
+++ b/dev/issue-49-hic-straw-transport-extension-points.html
@@ -1,0 +1,215 @@
+<html>
+<head>
+    <meta charSet="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>hic-straw #49 — transport extension points</title>
+
+    <style>
+        body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 24px; max-width: 980px; }
+        h1 { font-size: 20px; margin: 0 0 4px; }
+        h2 { font-size: 15px; margin: 0 0 8px; }
+        .sub { color: #666; margin: 0 0 24px; }
+        .probe { border: 1px solid #ddd; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
+        .probe > p { margin: 0 0 12px; color: #555; }
+        button { font: inherit; padding: 6px 14px; cursor: pointer; }
+        pre { background: #f6f6f6; padding: 12px; border-radius: 4px; overflow-x: auto; white-space: pre-wrap;
+              word-break: break-all; margin: 12px 0 0; font-size: 12px; }
+        .verdict { font-weight: 600; padding: 2px 8px; border-radius: 3px; }
+        .pass { background: #d7f7d7; color: #14601a; }
+        .fail { background: #ffdcdc; color: #8a1414; }
+        .pending { background: #eee; color: #666; }
+        code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; }
+    </style>
+</head>
+
+<body>
+
+<h1>hic-straw #49 — transport extension points</h1>
+<p class="sub">
+    Verifies the acceptance item that cannot be a unit test: a bot challenge keys on
+    <code>Origin</code>, which node never sends, so this must run in a browser at
+    <code>localhost</code>. Requires hic-straw &ge; 4.0.0 — <code>package.json</code> is pinned to
+    <code>github:aidenlab/hic-straw#master</code> on this branch and must be repinned to
+    <code>#v4.0.0</code> once that tag is cut.
+</p>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>1. Response detail — <span id="verdict-1" class="verdict pending">not run</span></h2>
+    <p>
+        Reads a blocked ENCODE URL through <code>Straw</code> and inspects the thrown error.
+        Passes when <code>err.headers.get('x-amzn-waf-action')</code> is <code>captcha</code> —
+        the signal that used to die inside hic-straw. Also confirms <code>err.message</code> is
+        non-empty, which <code>statusText</code> alone is not over HTTP/2.
+    </p>
+    <button id="run-1">Run</button>
+    <pre id="out-1">—</pre>
+</div>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>2. mapUrl composition — <span id="verdict-2" class="verdict pending">not run</span></h2>
+    <p>
+        Supplies a consumer <code>mapUrl</code> against a Dropbox URL that does not exist, and reads
+        the physical URL back off <code>err.url</code>. Passes when the failed fetch shows
+        <em>both</em> rewrites in the right order: hic-straw's default Dropbox rule applied first
+        (<code>www.dropbox.com</code> &rarr; <code>dl.dropboxusercontent.com</code>), then the
+        consumer rule on top. A consumer supplying <code>mapUrl</code> must not silently switch off
+        the default rules.
+    </p>
+    <button id="run-2">Run</button>
+    <pre id="out-2">—</pre>
+</div>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>3. Through juicebox.js — <span id="verdict-3" class="verdict pending">not run</span></h2>
+    <p>
+        The same blocked URL through <code>hic.createBrowser</code>, i.e. the path a real
+        application takes. Shows what juicebox.js surfaces to a user today. This probe is
+        <em>informational</em>: juicebox.js has no interpretation layer yet — that is the dev-proxy
+        work in this repo's <code>docs/adr/0001-dev-proxy-for-waf-protected-hosts.md</code>. What it
+        establishes is that the response detail survives the trip up through juicebox.js and is
+        available to build that layer on.
+    </p>
+    <button id="run-3">Run</button>
+    <div id="browser-container" style="display: none;"></div>
+    <pre id="out-3">—</pre>
+</div>
+
+<script type="module">
+
+    import Straw from 'hic-straw'
+    import hic from '../js/index.js'
+
+    // Blocked from any non-allowlisted Origin, localhost included. See
+    // docs/adr/0001-dev-proxy-for-waf-protected-hosts.md for the Origin matrix.
+    const BLOCKED_ENCODE_URL = 'https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic'
+
+    const setVerdict = (n, pass, label) => {
+        const el = document.getElementById(`verdict-${n}`)
+        el.className = `verdict ${pass ? 'pass' : 'fail'}`
+        el.textContent = label || (pass ? 'PASS' : 'FAIL')
+    }
+
+    const report = (n, lines) => document.getElementById(`out-${n}`).textContent = lines.join('\n')
+
+    const describeError = e => [
+        `message   ${e.message || '(empty)'}`,
+        `code      ${e.code === undefined ? '(absent)' : e.code}`,
+        `url       ${e.url || '(absent)'}`,
+        `headers   ${e.headers ? '(Headers instance)' : '(absent — failure preceded the response)'}`,
+    ]
+
+    // ------------------------------------------------------------------
+    // 1. Response detail: does the WAF header reach the consumer?
+    // ------------------------------------------------------------------
+    document.getElementById('run-1').onclick = async () => {
+        report(1, ['reading…'])
+        try {
+            await new Straw({url: BLOCKED_ENCODE_URL}).getMetaData()
+            setVerdict(1, false, 'INCONCLUSIVE')
+            report(1, [
+                'The read SUCCEEDED, so no bot challenge was served.',
+                '',
+                'This origin is allowlisted, or ENCODE has changed its WAF rules.',
+                'The probe cannot say anything about err.headers without a challenge.',
+                `origin    ${window.location.origin}`,
+            ])
+        } catch (e) {
+            const wafAction = e.headers ? e.headers.get('x-amzn-waf-action') : undefined
+            const pass = wafAction === 'captcha' && Boolean(e.message)
+            setVerdict(1, pass)
+            report(1, [
+                ...describeError(e),
+                '',
+                `x-amzn-waf-action        ${wafAction || '(absent)'}`,
+                `content-type             ${e.headers ? e.headers.get('content-type') || '(absent)' : '(absent)'}`,
+                '',
+                pass
+                    ? 'PASS — the captcha signal survived hic-straw and is readable here.'
+                    : wafAction
+                        ? 'FAIL — header present but err.message is empty; the HTTP/2 statusText fix regressed.'
+                        : [
+                            'FAIL — no x-amzn-waf-action on the error.',
+                            'Either the failure was not a bot challenge (check the status above),',
+                            'or err.headers did not survive. A cross-origin read can only see this',
+                            'header because the challenge response sets Access-Control-Expose-Headers.',
+                        ].join('\n'),
+            ])
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 2. mapUrl composes on top of the defaults, in that order
+    // ------------------------------------------------------------------
+    document.getElementById('run-2').onclick = async () => {
+        report(2, ['reading…'])
+
+        const logical = 'https://www.dropbox.com/scl/fi/issue-49-probe/does-not-exist.hic'
+        const consumerMapUrl = url => `${url}?issue-49-consumer-rule=applied`
+
+        try {
+            await new Straw({url: logical, mapUrl: consumerMapUrl}).getMetaData()
+            setVerdict(2, false, 'INCONCLUSIVE')
+            report(2, ['The read SUCCEEDED. This probe needs a URL that 404s to read err.url back.'])
+        } catch (e) {
+            const physical = e.url || ''
+            const defaultRuleApplied = physical.includes('//dl.dropboxusercontent.com')
+            const consumerRuleApplied = physical.includes('issue-49-consumer-rule=applied')
+            const pass = defaultRuleApplied && consumerRuleApplied
+
+            setVerdict(2, pass)
+            report(2, [
+                `logical url    ${logical}`,
+                `physical url   ${physical || '(absent — the failure preceded the response)'}`,
+                '',
+                `default Dropbox rule applied    ${defaultRuleApplied ? 'yes' : 'NO'}`,
+                `consumer rule applied           ${consumerRuleApplied ? 'yes' : 'NO'}`,
+                '',
+                pass
+                    ? 'PASS — normalize-then-route. The consumer rule saw the host the bytes come from.'
+                    : defaultRuleApplied
+                        ? 'FAIL — the consumer mapUrl was not applied.'
+                        : 'FAIL — supplying mapUrl switched off the default rules. That is the regression this composition ordering exists to prevent.',
+                '',
+                ...describeError(e),
+            ])
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 3. The same failure through the application path
+    // ------------------------------------------------------------------
+    document.getElementById('run-3').onclick = async () => {
+        report(3, ['loading…'])
+        const container = document.getElementById('browser-container')
+        container.style.display = 'block'
+        container.innerHTML = ''
+
+        try {
+            await hic.createBrowser(container, {url: BLOCKED_ENCODE_URL, name: 'ENCFF718AWL.hic'})
+            setVerdict(3, false, 'LOADED')
+            report(3, ['The map LOADED. No bot challenge from this origin — see probe 1.'])
+        } catch (e) {
+            // Informational: juicebox.js does not interpret the challenge yet.
+            const wafAction = e.headers ? e.headers.get('x-amzn-waf-action') : undefined
+            setVerdict(3, Boolean(e.message), Boolean(e.message) ? 'SURFACED' : 'EMPTY')
+            report(3, [
+                'What juicebox.js surfaces to the application:',
+                '',
+                ...describeError(e),
+                '',
+                `x-amzn-waf-action   ${wafAction || '(absent at this layer)'}`,
+                '',
+                wafAction
+                    ? 'The response detail survives up through juicebox.js — an interpretation layer can be built on it.'
+                    : 'The error reaching the application carries no headers. Check whether the failing read is the one probe 1 exercises, or whether an intermediate catch rethrew a plain Error.',
+            ])
+        }
+    }
+
+</script>
+
+</body>
+</html>

--- a/dev/issue-49-hic-straw-transport-extension-points.html
+++ b/dev/issue-49-hic-straw-transport-extension-points.html
@@ -26,11 +26,10 @@
 
 <h1>hic-straw #49 — transport extension points</h1>
 <p class="sub">
-    Verifies the acceptance item that cannot be a unit test: a bot challenge keys on
-    <code>Origin</code>, which node never sends, so this must run in a browser at
-    <code>localhost</code>. Requires hic-straw &ge; 4.0.0 — <code>package.json</code> is pinned to
-    <code>github:aidenlab/hic-straw#master</code> on this branch and must be repinned to
-    <code>#v4.0.0</code> once that tag is cut.
+    Verifies the acceptance items that cannot be unit tests: a bot challenge keys on
+    <code>Origin</code>, which node never sends, so these must run in a browser at
+    <code>localhost</code>. Requires hic-straw &ge; 4.0.0, which <code>package.json</code> is
+    pinned to.
 </p>
 
 <!-- ------------------------------------------------------------------ -->
@@ -66,11 +65,12 @@
     <h2>3. Through juicebox.js — <span id="verdict-3" class="verdict pending">not run</span></h2>
     <p>
         The same blocked URL through <code>hic.createBrowser</code>, i.e. the path a real
-        application takes. Shows what juicebox.js surfaces to a user today. This probe is
-        <em>informational</em>: juicebox.js has no interpretation layer yet — that is the dev-proxy
-        work in this repo's <code>docs/adr/0001-dev-proxy-for-waf-protected-hosts.md</code>. What it
-        establishes is that the response detail survives the trip up through juicebox.js and is
-        available to build that layer on.
+        application takes. Passes on three counts: the response detail survives the trip up through
+        juicebox.js (<code>err.headers</code> is still readable here); the alert dialog is actually
+        on screen; and its text names the bot challenge instead of the misleading <code>405</code>.
+        That last one is the whole point of issue #441 — see
+        <code>docs/adr/0001-dev-proxy-for-waf-protected-hosts.md</code>, "Making the failure
+        legible".
     </p>
     <button id="run-3">Run</button>
     <div id="browser-container" style="display: none;"></div>
@@ -187,14 +187,30 @@
         container.style.display = 'block'
         container.innerHTML = ''
 
+        // igv-ui reuses one dialog for the life of the page. Clear any left over from an earlier
+        // run so the assertions below can only read what this run produced.
+        const stale = document.querySelector('.igv-ui-alert-dialog-container')
+        if (stale) {
+            stale.style.display = 'none'
+            stale.querySelector('.igv-ui-alert-dialog-body-copy').textContent = ''
+        }
+
         try {
             await hic.createBrowser(container, {url: BLOCKED_ENCODE_URL, name: 'ENCFF718AWL.hic'})
             setVerdict(3, false, 'LOADED')
             report(3, ['The map LOADED. No bot challenge from this origin — see probe 1.'])
         } catch (e) {
-            // Informational: juicebox.js does not interpret the challenge yet.
             const wafAction = e.headers ? e.headers.get('x-amzn-waf-action') : undefined
-            setVerdict(3, Boolean(e.message), Boolean(e.message) ? 'SURFACED' : 'EMPTY')
+
+            // presentError runs synchronously inside loadHicFile's catch, before the rethrow that
+            // lands here, so the dialog is already up. igv-ui hides it with display: none.
+            const dialog = document.querySelector('.igv-ui-alert-dialog-container')
+            const alertText = document.querySelector('.igv-ui-alert-dialog-body-copy')?.textContent || ''
+            const shown = Boolean(dialog) && getComputedStyle(dialog).display !== 'none'
+            const legible = alertText.includes('bot protection') && !alertText.includes('405')
+
+            const pass = wafAction === 'captcha' && shown && legible
+            setVerdict(3, pass)
             report(3, [
                 'What juicebox.js surfaces to the application:',
                 '',
@@ -202,9 +218,18 @@
                 '',
                 `x-amzn-waf-action   ${wafAction || '(absent at this layer)'}`,
                 '',
-                wafAction
-                    ? 'The response detail survives up through juicebox.js — an interpretation layer can be built on it.'
-                    : 'The error reaching the application carries no headers. Check whether the failing read is the one probe 1 exercises, or whether an intermediate catch rethrew a plain Error.',
+                'What juicebox.js surfaces to the user:',
+                '',
+                `dialog on screen    ${shown ? 'yes' : 'NO'}`,
+                `dialog text         ${alertText || '(empty)'}`,
+                '',
+                pass
+                    ? 'PASS — the challenge is reported in plain language, not as a 405.'
+                    : !wafAction
+                        ? 'FAIL — the error reaching the application carries no headers. Check whether the failing read is the one probe 1 exercises, or whether an intermediate catch rethrew a plain Error.'
+                        : !shown
+                            ? 'FAIL — headers survived but no alert was presented. Check that loadHicFile\'s catch still calls presentError.'
+                            : 'FAIL — an alert was presented, but it does not name the bot challenge. Check isBotChallenge in js/utils.js.',
             ])
         }
     }

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -26,7 +26,7 @@ import {FileUtils} from 'igv-utils'
 import Dataset, { HiCDataset } from './hicDataset.js'
 import State from './hicState.js'
 import Genome from './genome.js'
-import {extractName, presentError} from "./utils.js"
+import {extractName, presentError, isBotChallenge} from "./utils.js"
 import {isFile} from "./fileUtils.js"
 import {getAllBrowsers, syncBrowsers} from "./createBrowser.js"
 import HICEvent from './hicEvent.js'
@@ -180,6 +180,14 @@ class DataLoader {
             this.browser.contactMapLabel.textContent = "";
             this.browser.contactMapLabel.title = "";
             config.name = name;
+
+            // A bot challenge is the one failure the host app cannot explain to the user, since the
+            // tell is a response header it never sees. Everything else is left to the host, which
+            // may already report the rethrow — see issue #441.
+            if (isBotChallenge(error)) {
+                presentError("Error loading map", error);
+            }
+
             throw error;
         } finally {
             this.browser.stopSpinner();

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -320,6 +320,13 @@ class DataLoader {
                 );
                 return undefined;
             }
+        } catch (error) {
+            // Same reasoning as loadHicFile: report only the failure the host app cannot explain.
+            if (isBotChallenge(error)) {
+                presentError("Error loading control map", error);
+            }
+
+            throw error;
         } finally {
             this.browser.userInteractionShield.style.display = 'none';
             this.browser.stopSpinner();

--- a/js/utils.js
+++ b/js/utils.js
@@ -77,7 +77,10 @@ function presentError(prefix, error) {
             404: "Not found"
         };
 
-    const msg = httpMessages[error.message] || error.message;
+    // hic-straw and igv both throw Error(statusText) with the numeric status on error.code, so
+    // that is the only reliable key. Codes arrive as either numbers or strings; object keys
+    // normalize both. See issue #442.
+    const msg = Object.hasOwn(httpMessages, error.code) ? httpMessages[error.code] : error.message;
     Alert.presentAlert(`${prefix}: ${msg}`);
 }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -69,7 +69,32 @@ function hitTestBbox(bboxes, value) {
     return undefined;
 }
 
+/**
+ * A bot challenge arrives under a misleading 405; the tell is the x-amzn-waf-action header, which
+ * hic-straw hangs off the thrown error. See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ *
+ * @param {Error} error - the error a load failed with
+ * @returns {boolean} - true if a bot challenge, rather than the request itself, caused the failure
+ */
+function isBotChallenge(error) {
+    // Not every thrower attaches headers: network errors, aborts and local file reads have none,
+    // and only a fetch Response supplies the case-insensitive Headers.get() this relies on.
+    return typeof error.headers?.get === 'function' && error.headers.get('x-amzn-waf-action') === 'captcha';
+}
+
+const botChallengeMessage =
+    "the data provider's bot protection blocked this request. " +
+    "The domain of the page making the request — this one — is most likely not on the " +
+    "provider's allowlist. " +
+    "See https://github.com/aidenlab/juicebox.js/issues/441";
+
 function presentError(prefix, error) {
+
+    if (isBotChallenge(error)) {
+        Alert.presentAlert(`${prefix}: ${botChallengeMessage}`);
+        return;
+    }
+
     const httpMessages =
         {
             401: "Access unauthorized",

--- a/js/utils.js
+++ b/js/utils.js
@@ -109,4 +109,4 @@ function presentError(prefix, error) {
     Alert.presentAlert(`${prefix}: ${msg}`);
 }
 
-export { createDOMFromHTMLString, getOffset, parseRgbString, prettyPrint, extractName, presentError, hitTestBbox }
+export { createDOMFromHTMLString, getOffset, parseRgbString, prettyPrint, extractName, presentError, isBotChallenge, hitTestBbox }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@vitest/ui": "^4.0.7",
         "atob": "^2.1.2",
         "btoa": "^1.2.1",
-        "hic-straw": "github:aidenlab/hic-straw#master",
+        "hic-straw": "github:aidenlab/hic-straw#v4.0.0",
         "igv": "^3.8.0",
         "igv-ui": "github:igvteam/igv-ui#v1.5.9",
         "igv-utils": "github:igvteam/igv-utils#v1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@vitest/ui": "^4.0.7",
         "atob": "^2.1.2",
         "btoa": "^1.2.1",
-        "hic-straw": "github:aidenlab/hic-straw#v3.0.1",
+        "hic-straw": "github:aidenlab/hic-straw#master",
         "igv": "^3.8.0",
         "igv-ui": "github:igvteam/igv-ui#v1.5.9",
         "igv-utils": "github:igvteam/igv-utils#v1.7.1",
@@ -1138,8 +1138,8 @@
       "license": "MIT"
     },
     "node_modules/hic-straw": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/aidenlab/hic-straw.git#0ec03d12dabcfed3b7fd7c7520262ef05364b95a",
+      "version": "4.0.0",
+      "resolved": "git+ssh://git@github.com/aidenlab/hic-straw.git#a046e1731f0e8cc333662516dfbe0a3108f66db7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1150,7 +1150,7 @@
         "straw": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/igv": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vitest/ui": "^4.0.7",
     "atob": "^2.1.2",
     "btoa": "^1.2.1",
-    "hic-straw": "github:aidenlab/hic-straw#master",
+    "hic-straw": "github:aidenlab/hic-straw#v4.0.0",
     "igv": "^3.8.0",
     "igv-ui": "github:igvteam/igv-ui#v1.5.9",
     "igv-utils": "github:igvteam/igv-utils#v1.7.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vitest/ui": "^4.0.7",
     "atob": "^2.1.2",
     "btoa": "^1.2.1",
-    "hic-straw": "github:aidenlab/hic-straw#v3.0.1",
+    "hic-straw": "github:aidenlab/hic-straw#master",
     "igv": "^3.8.0",
     "igv-ui": "github:igvteam/igv-ui#v1.5.9",
     "igv-utils": "github:igvteam/igv-utils#v1.7.1",

--- a/test/testDataLoaderErrors.js
+++ b/test/testDataLoaderErrors.js
@@ -1,0 +1,83 @@
+/**
+ * A challenged .hic map load used to reject out of HICBrowser.init to the host app with nothing
+ * shown to the user. loadHicFile now reports the bot challenge before rethrowing. See issue #441.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const presented = [];
+
+vi.mock('igv-ui', () => ({
+    Alert: {
+        presentAlert: (message) => presented.push(message),
+        init: () => undefined
+    }
+}));
+
+const loadDataset = vi.fn();
+
+vi.mock('../js/hicDataset.js', () => ({
+    default: { loadDataset: (...args) => loadDataset(...args) },
+    HiCDataset: class {}
+}));
+
+const { default: DataLoader } = await import("../js/dataLoader.js");
+
+function stubBrowser() {
+    return {
+        clearSession: () => undefined,
+        stopSpinner: () => undefined,
+        contactMatrixView: { startSpinner: () => undefined },
+        contactMapLabel: { textContent: "", title: "" },
+        userInteractionShield: { style: {} },
+        controlDataset: undefined
+    };
+}
+
+function challengeError() {
+    const error = Error("405 Method Not Allowed — https://www.encodeproject.org/x.hic");
+    error.code = 405;
+    error.headers = new Headers({ 'x-amzn-waf-action': 'captcha' });
+    return error;
+}
+
+describe("loadHicFile error reporting", function () {
+
+    beforeEach(() => {
+        presented.length = 0;
+        loadDataset.mockReset();
+    });
+
+    test("reports a bot challenge rather than failing silently", async function () {
+        loadDataset.mockRejectedValue(challengeError());
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicFile({ url: "https://www.encodeproject.org/x.hic" }))
+            .rejects.toThrow();
+
+        expect(presented).toHaveLength(1);
+        expect(presented[0]).toContain("bot protection");
+        expect(presented[0]).not.toContain("405");
+    });
+
+    test("still rethrows so the host app can handle the failure", async function () {
+        const error = challengeError();
+        loadDataset.mockRejectedValue(error);
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicFile({ url: "https://www.encodeproject.org/x.hic" }))
+            .rejects.toBe(error);
+    });
+
+    test("leaves ordinary load failures to the host app, unalerted", async function () {
+        const error = Error("Not Found");
+        error.code = 404;
+        loadDataset.mockRejectedValue(error);
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicFile({ url: "https://example.org/missing.hic" }))
+            .rejects.toBe(error);
+
+        expect(presented).toEqual([]);
+    });
+
+});

--- a/test/testDataLoaderErrors.js
+++ b/test/testDataLoaderErrors.js
@@ -81,3 +81,45 @@ describe("loadHicFile error reporting", function () {
     });
 
 });
+
+describe("loadHicControlFile error reporting", function () {
+
+    beforeEach(() => {
+        presented.length = 0;
+        loadDataset.mockReset();
+    });
+
+    test("reports a bot challenge rather than failing silently", async function () {
+        loadDataset.mockRejectedValue(challengeError());
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicControlFile({ url: "https://www.encodeproject.org/b.hic" }))
+            .rejects.toThrow();
+
+        expect(presented).toHaveLength(1);
+        expect(presented[0]).toContain("bot protection");
+        expect(presented[0]).not.toContain("405");
+    });
+
+    test("still rethrows so the host app can handle the failure", async function () {
+        const error = challengeError();
+        loadDataset.mockRejectedValue(error);
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicControlFile({ url: "https://www.encodeproject.org/b.hic" }))
+            .rejects.toBe(error);
+    });
+
+    test("leaves ordinary load failures to the host app, unalerted", async function () {
+        const error = Error("Not Found");
+        error.code = 404;
+        loadDataset.mockRejectedValue(error);
+        const dataLoader = new DataLoader(stubBrowser());
+
+        await expect(dataLoader.loadHicControlFile({ url: "https://example.org/missing.hic" }))
+            .rejects.toBe(error);
+
+        expect(presented).toEqual([]);
+    });
+
+});

--- a/test/testPresentError.js
+++ b/test/testPresentError.js
@@ -14,10 +14,13 @@ vi.mock('igv-ui', () => ({
 
 const { presentError } = await import("../js/utils.js");
 
-function alertFor(message, code) {
+function alertFor(message, code, headers) {
     const error = Error(message);
     if (code !== undefined) {
         error.code = code;
+    }
+    if (headers !== undefined) {
+        error.headers = headers;
     }
     presentError("Error loading map", error);
     return presented.at(-1);
@@ -52,6 +55,49 @@ describe("presentError", function () {
 
     test("does not treat inherited Object properties as status codes", function () {
         expect(alertFor("Bad Request", "toString")).toBe("Error loading map: Bad Request");
+    });
+
+    // Bot challenge — see issue #441 and docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+    describe("bot challenge", function () {
+
+        test("reports the cause rather than the misleading status", function () {
+            const headers = new Headers({ 'x-amzn-waf-action': 'captcha' });
+            const alert = alertFor("405 Method Not Allowed — https://www.encodeproject.org/x.hic", 405, headers);
+
+            expect(alert).not.toContain("405");
+            expect(alert).toContain("bot protection");
+            expect(alert).toContain("allowlist");
+            expect(alert).toContain("https://github.com/aidenlab/juicebox.js/issues/441");
+        });
+
+        test("matches the header case-insensitively", function () {
+            const headers = new Headers({ 'X-Amzn-Waf-Action': 'captcha' });
+
+            expect(alertFor("Method Not Allowed", 405, headers)).toContain("bot protection");
+        });
+
+        test("leaves an ordinary 403 with headers alone", function () {
+            const headers = new Headers({ 'content-type': 'text/html' });
+
+            expect(alertFor("Forbidden", 403, headers)).toBe("Error loading map: Access forbidden");
+        });
+
+        test("leaves a non-captcha waf action alone", function () {
+            const headers = new Headers({ 'x-amzn-waf-action': 'challenge' });
+
+            expect(alertFor("Method Not Allowed", 405, headers)).toBe("Error loading map: Method Not Allowed");
+        });
+
+        test("is safe when the error carries no headers", function () {
+            expect(alertFor("Failed to fetch")).toBe("Error loading map: Failed to fetch");
+        });
+
+        test("is safe when headers is not a Headers instance", function () {
+            const alert = alertFor("Failed to fetch", undefined, { 'x-amzn-waf-action': 'captcha' });
+
+            expect(alert).toBe("Error loading map: Failed to fetch");
+        });
+
     });
 
 });

--- a/test/testPresentError.js
+++ b/test/testPresentError.js
@@ -1,0 +1,57 @@
+/**
+ * presentError maps HTTP status codes to friendly alert text. The lookup used to be keyed on
+ * error.message, so it never fired. See issue #442.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const presented = [];
+
+vi.mock('igv-ui', () => ({
+    Alert: {
+        presentAlert: (message) => presented.push(message)
+    }
+}));
+
+const { presentError } = await import("../js/utils.js");
+
+function alertFor(message, code) {
+    const error = Error(message);
+    if (code !== undefined) {
+        error.code = code;
+    }
+    presentError("Error loading map", error);
+    return presented.at(-1);
+}
+
+describe("presentError", function () {
+
+    beforeEach(() => {
+        presented.length = 0;
+    });
+
+    test("maps a numeric http status code to a friendly message", function () {
+        expect(alertFor("Forbidden", 403)).toBe("Error loading map: Access forbidden");
+    });
+
+    test("maps a string http status code to a friendly message", function () {
+        expect(alertFor("Not Found", "404")).toBe("Error loading map: Not found");
+    });
+
+    test("maps 401 to a friendly message", function () {
+        expect(alertFor("Unauthorized", 401)).toBe("Error loading map: Access unauthorized");
+    });
+
+    test("falls back to the error message when there is no code", function () {
+        expect(alertFor("Something went sideways")).toBe("Error loading map: Something went sideways");
+    });
+
+    test("falls back to the error message for an unmapped code", function () {
+        const message = "500 Internal Server Error — https://example.org/x.hic";
+        expect(alertFor(message, 500)).toBe(`Error loading map: ${message}`);
+    });
+
+    test("does not treat inherited Object properties as status codes", function () {
+        expect(alertFor("Bad Request", "toString")).toBe("Error loading map: Bad Request");
+    });
+
+});


### PR DESCRIPTION
Reports bot-protection blocks in plain language instead of a bare `405`, and fixes the latent `presentError` bug found alongside it.

Unblocked by aidenlab/hic-straw#49 — hic-straw v4.0.0 now hangs the response `headers` off the thrown error, so juicebox can finally see `X-Amzn-Waf-Action: captcha`.

## Changes

- **Repin hic-straw to v4.0.0** — carries the transport extension points and the error `headers`.
- **`presentError` keys on `error.code` (#442)** — it was keyed on `error.message`, so the 401/403/404 table never matched. Both hic-straw and igv throw `Error(statusText)` with the numeric status on `error.code`.
- **`isBotChallenge(error)` (#441)** — checks `error.headers?.get('x-amzn-waf-action') === 'captcha'`, guarded so network errors, aborts and local file reads (which have no `headers`) are safe.
- **Report it on both load paths** — `loadHicFile` and the control-map path in `js/dataLoader.js`. Only the bot challenge is surfaced here; every other failure is still left to the host app, which may already report the rethrow.
- **Browser harness** for the hic-straw #49 extension points, listed on the dashboard. Probe 3 asserts the alert dialog actually appears.

## Testing

`npm test` — 227 passing, including new `test/testPresentError.js` and `test/testDataLoaderErrors.js` covering the challenge path, the unchanged 401/403/404 messages, and the absent-`headers` case.

## Not in this PR

- #440 (dev-time proxy for WAF-protected hosts) — still unstarted.
- The v3.4.3 tag #441 asks for. Spacewalk pins `#v3.4.2` and gets nothing until that tag is cut.

Closes #441
Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
