### PR TITLE
Dev-time proxy for hosts that serve a bot challenge (#440)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,31 @@ This opens a dashboard at `http://localhost:3000` with links to all available pa
 
 Note: The Vite dev server is required because the source files use bare npm import specifiers and SCSS, which browsers cannot resolve from a plain static file server.
 
+## Loading maps from hosts that serve a bot challenge
+
+Some data hosts — `www.encodeproject.org` today — put AWS WAF in front of their files and answer any origin not on their allowlist with a CAPTCHA page, under a misleading `405`. `localhost` is never allowlisted, so those maps cannot be loaded in development without help.
+
+`dev-proxy/` is a **development-only** workaround: a Vite plugin that fetches the file from Node with an allowlisted `Origin` and hands the resulting redirect back to the browser, plus the client-side rule that decides which hosts get routed that way. It is already wired into this repo's dev server — see `dev/encode-dev-proxy.html`. In a host application:
+
+```js
+// vite.config.js
+import { devProxy } from 'juicebox.js/dev-proxy/plugin'
+
+export default defineConfig({ plugins: [devProxy()] })
+```
+
+```js
+// app startup
+import hic from 'juicebox.js'
+import { devMapUrl } from 'juicebox.js/dev-proxy/map-url'
+
+if (import.meta.env.DEV) hic.setUrlMapper(devMapUrl)
+```
+
+`devProxy()` takes an `origin` option (default `https://aidenlab.org`) — the `Origin` the proxy claims. Set it to a domain you actually control.
+
+`apply: 'serve'` means the plugin can never enter a production build, and `setUrlMapper` is unset by default: a host app that never calls it behaves exactly as before. Only `.hic` reads through hic-straw are covered. See `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.
+
 This creates a dist folder with the following files
 
 * juicebox.js - ES5 compatible file.  A script include will define the "juicebox" global.

--- a/dashboard.html
+++ b/dashboard.html
@@ -154,6 +154,7 @@
             { name: 'Bug: Daphne Qin 10bp to 1bp', path: 'dev/bug-daphne-qin-10bp_to_1bp.html' },
             { name: 'Bug: Daphne Qin Vanishing 2D Annotation', path: 'dev/bug-daphne-qin-vanishing-2d-annotation.html' },
             { name: 'DAT Sequence Gene Track', path: 'dev/dat-sequence-gene-track.html' },
+            { name: 'Issue 440: ENCODE Dev Proxy', path: 'dev/encode-dev-proxy.html' },
             { name: 'Generic Test Harness', path: 'dev/generic-test-harness.html' },
             { name: 'Issue 49: hic-straw Transport Extension Points', path: 'dev/issue-49-hic-straw-transport-extension-points.html' },
             { name: 'jQuery Cleanse', path: 'dev/jquery-cleanse.html' },

--- a/dev-proxy/map-url.js
+++ b/dev-proxy/map-url.js
@@ -1,0 +1,82 @@
+/**
+ * The client-side half of the dev proxy: the URL mapper a host app registers in development.
+ *
+ *     import hic from 'juicebox.js'
+ *     import { devMapUrl } from 'juicebox.js/dev-proxy/map-url'
+ *
+ *     if (import.meta.env.DEV) hic.setUrlMapper(devMapUrl)
+ *
+ * Only hosts known to answer with a bot challenge are rewritten. Every other host keeps fetching
+ * directly, so a genuine CORS or permissions problem still surfaces in development exactly as it
+ * would in production — routing everything through Node would hide precisely the class of bug this
+ * library exists to hit.
+ *
+ * Note the asymmetry with the middleware in plugin.js, which is generic: proxy targets arrive from
+ * session files and user paste and cannot be enumerated. Only this rule is host-scoped.
+ *
+ * See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+
+/**
+ * Hosts that answer a non-allowlisted Origin with a bot challenge. Adding a host here and nothing
+ * else is the whole fix for the next one that starts challenging.
+ */
+const CHALLENGED_HOSTS = new Set(['www.encodeproject.org'])
+
+/**
+ * The middleware's mount point. The target follows it verbatim, so a proxied read is legible in
+ * devtools and the middleware can read the target back with a slice.
+ */
+const PROXY_PREFIX = '/__hic-proxy/'
+
+/**
+ * @param {string} url
+ * @returns {URL | undefined} the parsed URL, or undefined when it is not an absolute http(s) one —
+ *          a relative path, a bare filename, a blob: URL, or something that is not a string at all.
+ */
+function parseHttpUrl(url) {
+    if (typeof url !== 'string') {
+        return undefined
+    }
+    try {
+        const parsed = new URL(url)
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed : undefined
+    } catch (e) {
+        return undefined
+    }
+}
+
+/**
+ * The one place a proxy path is built, paired with targetFromProxyPath below.
+ *
+ * @param {string} url - an absolute http(s) URL.
+ * @returns {string} the path the dev server's middleware answers on.
+ */
+function toProxyPath(url) {
+    return `${PROXY_PREFIX}${url}`
+}
+
+/**
+ * @param {string} path - a request path known to start with PROXY_PREFIX.
+ * @returns {string} the target URL it names, still to be validated by the caller.
+ */
+function targetFromProxyPath(path) {
+    return path.slice(PROXY_PREFIX.length)
+}
+
+/**
+ * @param {string} url - the URL hic-straw is about to fetch, after its own default rewrites.
+ * @returns {string} the same URL, or a proxy path when the host is known to challenge.
+ */
+function devMapUrl(url) {
+
+    if (typeof url !== 'string' || url.startsWith(PROXY_PREFIX)) {
+        return url
+    }
+
+    const parsed = parseHttpUrl(url)
+
+    return parsed && CHALLENGED_HOSTS.has(parsed.host) ? toProxyPath(url) : url
+}
+
+export { devMapUrl, parseHttpUrl, toProxyPath, targetFromProxyPath, PROXY_PREFIX }

--- a/dev-proxy/plugin.js
+++ b/dev-proxy/plugin.js
@@ -1,0 +1,159 @@
+/**
+ * The server-side half of the dev proxy: a Vite plugin that fetches a challenged data host from
+ * Node, where the Origin header is ours to set.
+ *
+ *     import { devProxy } from 'juicebox.js/dev-proxy/plugin'
+ *
+ *     export default defineConfig({ plugins: [devProxy()] })
+ *
+ * `apply: 'serve'` so it can never enter a production build.
+ *
+ * The middleware is deliberately generic across hosts — targets arrive from session files and user
+ * paste and cannot be enumerated. The decision about *which* hosts get proxied is the client-side
+ * rule in map-url.js.
+ *
+ * See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+
+import { PROXY_PREFIX, parseHttpUrl, targetFromProxyPath } from './map-url.js'
+
+/**
+ * The Origin the proxy claims. aidenlab.org is this project's own domain and its own entry on
+ * ENCODE's allowlist, asserted by its own developers. The plugin option exists so that anyone
+ * outside aidenlab has an honest path rather than silently asserting someone else's identity.
+ */
+const DEFAULT_ORIGIN = 'https://aidenlab.org'
+
+/**
+ * The proxy identifies itself honestly rather than impersonating a browser.
+ *
+ * Measured against ENCODE on 2026-08-02, correcting the ADR as written: `Origin` alone decides the
+ * challenge, and a spoofed Chrome User-Agent is actively harmful. With an allowlisted Origin, an
+ * honest UA, a Firefox UA and no UA at all all return 307; `Chrome/126.0.0.0` returns **502** from
+ * awselb, with or without the sec-ch-ua hints. The bot challenge itself fires on a browser UA with
+ * a non-allowlisted Origin — which is what made the header set look load-bearing.
+ *
+ * The Sec-Fetch-* trio is what a browser's own cross-origin fetch would send and is verified
+ * harmless; it stays so the proxied request resembles the request being stood in for.
+ */
+const REQUEST_HEADERS = {
+    'User-Agent': 'juicebox.js-dev-proxy (+https://github.com/aidenlab/juicebox.js)',
+    'Accept': '*/*',
+    'Sec-Fetch-Site': 'cross-site',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Dest': 'empty'
+}
+
+/**
+ * Headers that describe the hop rather than the payload. `fetch` has already decoded the body, so
+ * relaying content-encoding or a content-length measured before decoding would describe a body the
+ * browser is not going to receive.
+ */
+const HOP_BY_HOP = new Set([
+    'connection', 'keep-alive', 'transfer-encoding', 'content-encoding', 'content-length',
+    'upgrade', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailer'
+])
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.origin] - the Origin the proxy claims.
+ * @returns {(req, res, next) => Promise<void>} connect middleware.
+ */
+function createProxyMiddleware({ origin = DEFAULT_ORIGIN } = {}) {
+
+    return async function hicProxy(req, res, next) {
+
+        if (!req.url || !req.url.startsWith(PROXY_PREFIX)) {
+            return next()
+        }
+
+        const target = targetFromProxyPath(req.url)
+
+        if (!parseHttpUrl(target)) {
+            return fail(res, 400, `hic dev proxy: not an absolute http(s) URL — ${target}`)
+        }
+
+        // Only Range is forwarded from the browser. Everything else is ours: forwarding the
+        // browser's Origin is the very thing that gets challenged, and its Host and Cookie belong
+        // to the dev server, not to the data host.
+        const headers = { ...REQUEST_HEADERS, Origin: origin }
+        if (req.headers?.range) {
+            headers.Range = req.headers.range
+        }
+
+        let response
+        try {
+            response = await fetch(target, { method: req.method || 'GET', headers, redirect: 'manual' })
+        } catch (e) {
+            return fail(res, 502, `hic dev proxy: ${e.message}`)
+        }
+
+        // Hand the redirect back rather than following it. The browser fetches the signed S3 URL
+        // directly, so the map bytes never cross Node and nothing here can corrupt a
+        // 206 Partial Content or its Content-Range — which would break .hic reading outright.
+        if (REDIRECT_STATUSES.has(response.status)) {
+            const location = response.headers.get('location')
+            response.body?.cancel()
+            if (!location) {
+                return fail(res, 502, 'hic dev proxy: redirect without a Location header')
+            }
+            res.statusCode = response.status
+            res.setHeader('Location', location)
+            res.setHeader('Cache-Control', 'no-store')
+            return res.end()
+        }
+
+        // Anything else is a small payload in practice — a bot challenge page or another error,
+        // since the challenged hosts answer a successful read with a redirect. Buffering keeps the
+        // relay simple and lets Node set an accurate Content-Length.
+        let body
+        try {
+            body = Buffer.from(await response.arrayBuffer())
+        } catch (e) {
+            return fail(res, 502, `hic dev proxy: ${e.message}`)
+        }
+        relayHeaders(response, res)
+        res.statusCode = response.status
+        res.end(body)
+    }
+}
+
+function relayHeaders(response, res) {
+    for (const [name, value] of response.headers) {
+        if (!HOP_BY_HOP.has(name.toLowerCase())) {
+            res.setHeader(name, value)
+        }
+    }
+    // The signal that names a bot challenge is a response header, and juicebox reads it off the
+    // thrown error to report the failure in plain language. Vacuous when the page and the dev
+    // server share an origin, which is the usual case; it costs nothing and covers the setup where
+    // they do not.
+    res.setHeader('Access-Control-Expose-Headers', '*')
+    res.setHeader('Cache-Control', 'no-store')
+}
+
+function fail(res, statusCode, message) {
+    res.statusCode = statusCode
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+    res.end(message)
+}
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.origin] - the Origin the proxy claims. Defaults to https://aidenlab.org.
+ * @returns {import('vite').Plugin}
+ */
+function devProxy(options = {}) {
+    return {
+        name: 'juicebox-hic-dev-proxy',
+        apply: 'serve',
+        configureServer(server) {
+            server.middlewares.use(createProxyMiddleware(options))
+        }
+    }
+}
+
+export { devProxy, createProxyMiddleware, DEFAULT_ORIGIN }
+export default devProxy

--- a/dev/encode-dev-proxy.html
+++ b/dev/encode-dev-proxy.html
@@ -1,0 +1,206 @@
+<html>
+<head>
+    <meta charSet="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>issue #440 — dev proxy for WAF-protected hosts</title>
+
+    <style>
+        body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 24px; max-width: 980px; }
+        h1 { font-size: 20px; margin: 0 0 4px; }
+        h2 { font-size: 15px; margin: 0 0 8px; }
+        .sub { color: #666; margin: 0 0 24px; }
+        .probe { border: 1px solid #ddd; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
+        .probe > p { margin: 0 0 12px; color: #555; }
+        button { font: inherit; padding: 6px 14px; cursor: pointer; }
+        pre { background: #f6f6f6; padding: 12px; border-radius: 4px; overflow-x: auto; white-space: pre-wrap;
+              word-break: break-all; margin: 12px 0 0; font-size: 12px; }
+        .verdict { font-weight: 600; padding: 2px 8px; border-radius: 3px; }
+        .pass { background: #d7f7d7; color: #14601a; }
+        .fail { background: #ffdcdc; color: #8a1414; }
+        .pending { background: #eee; color: #666; }
+        code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; }
+        #browser-container { margin-top: 12px; }
+    </style>
+</head>
+
+<body>
+
+<h1>issue #440 — dev proxy for WAF-protected hosts</h1>
+<p class="sub">
+    Checks the acceptance items that cannot be unit tests, because a bot challenge keys on
+    <code>Origin</code> and only a browser at <code>localhost</code> sends the failing one. This page
+    calls <code>hic.setUrlMapper(devMapUrl)</code> on load — the one line a host app adds in
+    development. See <code>docs/adr/0001-dev-proxy-for-waf-protected-hosts.md</code>.
+</p>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>1. The rewrite is host-scoped — <span id="verdict-1" class="verdict pending">not run</span></h2>
+    <p>
+        No network. Confirms the registered mapper routes ENCODE through
+        <code>/__hic-proxy/</code> and leaves every other host in the session-file set fetching
+        directly, so a real CORS or permissions problem still surfaces here as it would in
+        production.
+    </p>
+    <button id="run-1">Run</button>
+    <pre id="out-1">—</pre>
+</div>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>2. The proxy returns the redirect — <span id="verdict-2" class="verdict pending">not run</span></h2>
+    <p>
+        Fetches one byte range through the proxy with <code>redirect: 'manual'</code>, so the
+        redirect is visible rather than followed. Passes when the proxy answers <code>307</code> with
+        a <code>Location</code> pointing at a different host: the map bytes come from S3 straight to
+        the browser, never through Node.
+    </p>
+    <button id="run-2">Run</button>
+    <pre id="out-2">—</pre>
+</div>
+
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>3. An ENCODE map loads from localhost — <span id="verdict-3" class="verdict pending">not run</span></h2>
+    <p>
+        The acceptance criterion. The same URL that fails with a bot challenge on <code>master</code>
+        loads through <code>hic.createBrowser</code>. Watch the network panel: the
+        <code>/__hic-proxy/</code> request is the redirect only; every range request that follows
+        goes directly to S3 as <code>206 Partial Content</code>.
+    </p>
+    <button id="run-3">Run</button>
+    <pre id="out-3">—</pre>
+    <div id="browser-container"></div>
+</div>
+
+<script type="module">
+
+    import hic from '../js/index.js'
+    import { devMapUrl, PROXY_PREFIX } from '../dev-proxy/map-url.js'
+
+    // The one line a host app adds. In a host app it is guarded by import.meta.env.DEV; this page
+    // only ever runs under the dev server.
+    hic.setUrlMapper(devMapUrl)
+
+    // Blocked from any non-allowlisted Origin, localhost included.
+    const ENCODE_URL = 'https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic'
+
+    const setVerdict = (n, pass, label) => {
+        const el = document.getElementById(`verdict-${n}`)
+        el.className = `verdict ${pass ? 'pass' : 'fail'}`
+        el.textContent = label || (pass ? 'PASS' : 'FAIL')
+    }
+
+    const report = (n, lines) => document.getElementById(`out-${n}`).textContent = lines.join('\n')
+
+    // ------------------------------------------------------------------
+    // 1. Only the challenged host is rewritten
+    // ------------------------------------------------------------------
+    document.getElementById('run-1').onclick = () => {
+
+        const direct = [
+            'https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/x.hic',
+            'https://ftp.ncbi.nlm.nih.gov/geo/samples/x.hic',
+            'https://s3.us-east-1.wasabisys.com/x.hic',
+            'https://s3.amazonaws.com/hicfiles/x.hic',
+        ]
+
+        const encodeMapped = devMapUrl(ENCODE_URL)
+        const encodeProxied = encodeMapped === `${PROXY_PREFIX}${ENCODE_URL}`
+        const untouched = direct.filter(url => devMapUrl(url) === url)
+        const pass = encodeProxied && untouched.length === direct.length
+
+        setVerdict(1, pass)
+        report(1, [
+            `encodeproject.org   ${encodeMapped}`,
+            '',
+            ...direct.map(url => `${devMapUrl(url) === url ? 'direct  ' : 'PROXIED '}${url}`),
+            '',
+            pass
+                ? 'PASS — ENCODE is routed, everything else is untouched.'
+                : encodeProxied
+                    ? 'FAIL — a host that should fetch directly was rewritten. Check CHALLENGED_HOSTS in dev-proxy/map-url.js.'
+                    : 'FAIL — the ENCODE URL was not rewritten.',
+        ])
+    }
+
+    // ------------------------------------------------------------------
+    // 2. The proxy hands the redirect back rather than following it
+    // ------------------------------------------------------------------
+    document.getElementById('run-2').onclick = async () => {
+        report(2, ['fetching…'])
+
+        try {
+            const response = await fetch(devMapUrl(ENCODE_URL), {
+                headers: {Range: 'bytes=0-99'},
+                redirect: 'manual'
+            })
+
+            // redirect: 'manual' yields an opaqueredirect response, which hides status and
+            // headers. Ask the dev server for the same thing with the redirect exposed instead.
+            const probe = await fetch(devMapUrl(ENCODE_URL), {headers: {Range: 'bytes=0-99'}})
+            const followedTo = probe.url
+            const differentHost = Boolean(followedTo) && new URL(followedTo).host !== 'www.encodeproject.org'
+            const partial = probe.status === 206
+            const pass = response.type === 'opaqueredirect' && differentHost && partial
+
+            setVerdict(2, pass)
+            report(2, [
+                `manual fetch type    ${response.type}`,
+                '',
+                'following the redirect:',
+                `final url            ${followedTo || '(absent)'}`,
+                `status               ${probe.status}`,
+                `content-range        ${probe.headers.get('content-range') || '(absent)'}`,
+                '',
+                pass
+                    ? 'PASS — the proxy answered with a redirect and the bytes came from another host.'
+                    : response.type !== 'opaqueredirect'
+                        ? 'FAIL — the proxy did not answer with a redirect. It may be following the 307 server-side, which would put the map bytes through Node.'
+                        : !differentHost
+                            ? 'FAIL — the redirect stayed on encodeproject.org.'
+                            : `FAIL — expected 206 Partial Content, got ${probe.status}. The Range header did not survive the redirect.`,
+            ])
+        } catch (e) {
+            setVerdict(2, false)
+            report(2, [`${e.message}`, '', 'Is the dev server running with devProxy() in vite.config.js?'])
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 3. The acceptance criterion: the map loads
+    // ------------------------------------------------------------------
+    document.getElementById('run-3').onclick = async () => {
+        report(3, ['loading…'])
+        const container = document.getElementById('browser-container')
+        container.innerHTML = ''
+
+        try {
+            const browser = await hic.createBrowser(container, {url: ENCODE_URL, name: 'ENCFF718AWL.hic'})
+            setVerdict(3, true)
+            report(3, [
+                `genome        ${browser.dataset.genomeId}`,
+                `chromosomes   ${browser.dataset.chromosomes.length}`,
+                `resolutions   ${browser.dataset.bpResolutions.length}`,
+                '',
+                'PASS — an ENCODE-hosted .hic loaded from localhost.',
+            ])
+        } catch (e) {
+            setVerdict(3, false)
+            report(3, [
+                `message   ${e.message || '(empty)'}`,
+                `code      ${e.code === undefined ? '(absent)' : e.code}`,
+                `url       ${e.url || '(absent)'}`,
+                `waf       ${e.headers?.get('x-amzn-waf-action') || '(absent)'}`,
+                '',
+                e.headers?.get('x-amzn-waf-action') === 'captcha'
+                    ? 'FAIL — still challenged. The proxy Origin is not on the allowlist, or the read did not go through the mapper.'
+                    : 'FAIL — see the message above.',
+            ])
+        }
+    }
+
+</script>
+
+</body>
+</html>

--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -19,9 +19,10 @@ Server: awselb/2.0
 Content-Type: text/html          (a challenge page, not the .hic file)
 ```
 
-Reproduction — same request throughout, varying only `Origin`. Browser-like
-headers (`User-Agent`, `Sec-Fetch-*`) are required; plain curl is not challenged,
-which is what made this hard to see:
+Reproduction — same request throughout, varying only `Origin`. A browser-like
+`User-Agent` is required to see the challenge at all; plain curl is not
+challenged, which is what made this hard to find (but see the 2026-08-02
+amendment below — the proxy must **not** send one):
 
 | `Origin` | Result |
 |---|---|
@@ -159,6 +160,36 @@ being a lie.
 - The allowlist of proxied hosts must be maintained. The next host that starts
   challenging is a fresh mystery until someone adds it — mitigated by the
   legible error, which names the cause.
+
+## Amendment, 2026-08-02 — the proxy sends an honest User-Agent
+
+Implementing this (issue #440) turned up a measurement that contradicts the
+header advice above. Sending an allowlisted `Origin` **and** a spoofed Chrome
+`User-Agent` gets `502 Bad Gateway` from `awselb/2.0`. Reproduced with both curl
+and Node `fetch`, against `ENCFF718AWL.hic`:
+
+| `Origin` | `User-Agent` | Result |
+|---|---|---|
+| `https://aidenlab.org` | *(absent)* | 307 → file served |
+| `https://aidenlab.org` | `juicebox.js-dev-proxy (+…)` | 307 → file served |
+| `https://aidenlab.org` | `Mozilla/5.0 … Firefox/127.0` | 307 → file served |
+| `https://aidenlab.org` | `Mozilla/5.0 … Chrome/126.0.0.0 …` | **502** |
+| `https://aidenlab.org` | Chrome + `sec-ch-ua` hints | **502** |
+| *(absent)* or `http://localhost:3000` | `Mozilla/5.0 … Chrome/126.0.0.0 …` | 405 + `X-Amzn-Waf-Action: captcha` |
+
+So `Origin` alone decides the bot challenge, and the browser-like headers are not
+load-bearing — they only made the challenge *visible* during diagnosis, because
+the challenge fires on a browser `User-Agent` from a non-allowlisted origin.
+Impersonating a specific browser version is the one thing that actively breaks.
+
+The proxy therefore identifies itself as `juicebox.js-dev-proxy`. It keeps the
+`Sec-Fetch-*` trio, which is what the browser's own cross-origin fetch would send
+and is verified harmless. This also sits better with the reasoning about `Origin`
+above: assert only your own identity.
+
+Why the 502 rather than a challenge is a guess — most likely a WAF rule on a
+Chrome `User-Agent` unaccompanied by the rest of a real Chrome fingerprint. It is
+ENCODE's rule to change, so pin nothing to it beyond "do not impersonate".
 
 ## Reversal
 

--- a/js/hicDataset.js
+++ b/js/hicDataset.js
@@ -27,6 +27,7 @@
  */
 
 import {isFile} from "./fileUtils.js"
+import {getUrlMapper} from "./urlMapper.js"
 import Straw from 'hic-straw'
 
 const knownGenomes = {
@@ -221,7 +222,11 @@ class HiCDataset extends Dataset {
 
     constructor(config) {
         super(config);
-        this.straw = new Straw(config)
+
+        // A mapper registered via setUrlMapper applies to every read unless this caller supplied
+        // one of its own. See js/urlMapper.js.
+        const mapUrl = config.mapUrl || getUrlMapper()
+        this.straw = new Straw(mapUrl ? {...config, mapUrl} : config)
         this.isLive = Boolean(config.liveContactMap);
         this.datasetType = this.isLive ? 'live' : 'hic';
     }

--- a/js/index.js
+++ b/js/index.js
@@ -28,6 +28,7 @@ import {version} from "./version.js";
 import {compressedSession, restoreSession, toJSON} from "./session.js";
 import {init} from "./init.js"
 import EventBus from "./eventBus.js"
+import {setUrlMapper} from "./urlMapper.js"
 
 export default {
     version,
@@ -40,5 +41,6 @@ export default {
     setCurrentBrowser,
     getAllBrowsers,
     igvxhr,
-    EventBus
+    EventBus,
+    setUrlMapper
 }

--- a/js/urlMapper.js
+++ b/js/urlMapper.js
@@ -1,0 +1,36 @@
+/**
+ * The URL mapper — the function juicebox hands to hic-straw as `config.mapUrl` to rewrite a .hic
+ * URL before it is fetched.
+ *
+ * It exists so development against an origin-restricted data host does not require patching global
+ * fetch. juicebox.js cannot decide for itself whether it is running in development: consumers
+ * install it from git, npm runs `prepare` -> `vite build`, and `import.meta.env.DEV` is baked to
+ * false in the resulting dist at *juicebox.js's* build time. The switch has to be thrown from
+ * outside, by the host app:
+ *
+ *     if (import.meta.env.DEV) hic.setUrlMapper(devMapUrl)
+ *
+ * Unset by default. A host app that never calls setUrlMapper behaves exactly as it did before this
+ * seam existed. See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+
+let urlMapper
+
+/**
+ * Register the mapper applied to every subsequent .hic read. Called once at host-app startup.
+ *
+ * @param {(url: string) => string} [mapper] - synchronous, pure, URL in / URL out. Pass undefined
+ *        to clear.
+ */
+function setUrlMapper(mapper) {
+    urlMapper = mapper
+}
+
+/**
+ * @returns {((url: string) => string) | undefined} the registered mapper, or undefined.
+ */
+function getUrlMapper() {
+    return urlMapper
+}
+
+export { setUrlMapper, getUrlMapper }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     },
     "./dist/juicebox.esm.js": "./dist/juicebox.esm.js",
     "./dist/juicebox.min.js": "./dist/juicebox.min.js",
-    "./dist/css/juicebox.css": "./dist/css/juicebox.css"
+    "./dist/css/juicebox.css": "./dist/css/juicebox.css",
+    "./dev-proxy/plugin": "./dev-proxy/plugin.js",
+    "./dev-proxy/map-url": "./dev-proxy/map-url.js"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "dev-proxy/**"
   ],
   "author": {
     "name": "Jim Robinson"

--- a/test/testDevMapUrl.js
+++ b/test/testDevMapUrl.js
@@ -1,0 +1,78 @@
+/**
+ * The client-side half of the dev proxy. It rewrites only hosts known to serve a bot challenge, so
+ * that a genuine CORS or permissions problem on any other host still surfaces in development
+ * exactly as it would in production.
+ *
+ * See issue #440 and docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+import { describe, test, expect } from 'vitest';
+import { devMapUrl, targetFromProxyPath, PROXY_PREFIX } from "../dev-proxy/map-url.js";
+
+const ENCODE_URL = "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic";
+
+describe("devMapUrl", function () {
+
+    test("routes a challenged host through the proxy", function () {
+        expect(devMapUrl(ENCODE_URL)).toBe(`${PROXY_PREFIX}${ENCODE_URL}`);
+    });
+
+    test("keeps the target URL whole, so the middleware can read it back", function () {
+        expect(targetFromProxyPath(devMapUrl(ENCODE_URL))).toBe(ENCODE_URL);
+    });
+
+    test("preserves a query string on the target", function () {
+        const withQuery = `${ENCODE_URL}?proxy=1`;
+
+        expect(devMapUrl(withQuery)).toBe(`${PROXY_PREFIX}${withQuery}`);
+    });
+
+    test("is idempotent — an already-proxied URL is left alone", function () {
+        const mapped = devMapUrl(ENCODE_URL);
+
+        expect(devMapUrl(mapped)).toBe(mapped);
+    });
+
+    describe("leaves every other host fetching directly", function () {
+
+        const untouched = [
+            "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/x.hic",
+            "https://ftp.ncbi.nlm.nih.gov/geo/samples/x.hic",
+            "https://s3.us-east-1.wasabisys.com/x.hic",
+            "https://s3.amazonaws.com/hicfiles/x.hic",
+            "https://dl.dropboxusercontent.com/s/x.hic",
+            "https://encodeproject.org.evil.example/x.hic",
+            "https://www.encodeproject.org.evil.example/x.hic",
+        ];
+
+        for (const url of untouched) {
+            test(url, function () {
+                expect(devMapUrl(url)).toBe(url);
+            });
+        }
+
+    });
+
+    describe("passes through anything that is not an absolute http(s) URL", function () {
+
+        const passThrough = {
+            "a relative path": "/data/test.hic",
+            "a bare filename": "test.hic",
+            "a blob url": "blob:http://localhost:3000/8f1b-4c2e",
+            "an empty string": "",
+        };
+
+        for (const [label, url] of Object.entries(passThrough)) {
+            test(label, function () {
+                expect(devMapUrl(url)).toBe(url);
+            });
+        }
+
+        test("a non-string argument", function () {
+            const file = { name: "test.hic" };
+
+            expect(devMapUrl(file)).toBe(file);
+        });
+
+    });
+
+});

--- a/test/testDevProxyMiddleware.js
+++ b/test/testDevProxyMiddleware.js
@@ -1,0 +1,279 @@
+/**
+ * The server-side half of the dev proxy. Unlike the client-side rewrite it is generic across
+ * hosts, because targets arrive from session files and user paste and cannot be enumerated.
+ *
+ * The behaviour that matters most: it returns ENCODE's 307 to the browser rather than following it
+ * server-side, so the map bytes never cross Node and there is no way for the proxy to corrupt
+ * Content-Range. See issue #440 and docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createProxyMiddleware, DEFAULT_ORIGIN } from "../dev-proxy/plugin.js";
+import { PROXY_PREFIX } from "../dev-proxy/map-url.js";
+
+const ENCODE_URL = "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic";
+const S3_URL = "https://encode-public.s3.amazonaws.com/2020/x.hic?X-Amz-Signature=abc";
+
+let fetched;
+
+function fakeRes() {
+    return {
+        statusCode: undefined,
+        headers: {},
+        body: undefined,
+        ended: false,
+        setHeader(name, value) {
+            this.headers[name.toLowerCase()] = value;
+        },
+        end(body) {
+            this.body = body;
+            this.ended = true;
+        }
+    };
+}
+
+function stubFetch(response) {
+    global.fetch = vi.fn(async (url, init) => {
+        fetched.push({ url, init });
+        return typeof response === 'function' ? response() : response;
+    });
+}
+
+/** A Response whose body must not be read — reading it means Node saw the map bytes. */
+function redirectResponse(location) {
+    return new Response(null, { status: 307, headers: { location } });
+}
+
+async function run(req, { origin } = {}) {
+    const res = fakeRes();
+    const next = vi.fn();
+    await createProxyMiddleware({ origin })(req, res, next);
+    return { res, next };
+}
+
+const proxyReq = (target, headers = {}) => ({ url: `${PROXY_PREFIX}${target}`, method: 'GET', headers });
+
+describe("dev proxy middleware", function () {
+
+    beforeEach(() => {
+        fetched = [];
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        delete global.fetch;
+    });
+
+    describe("routing", function () {
+
+        test("passes an unrelated request straight through", async function () {
+            stubFetch(new Response("never"));
+
+            const { res, next } = await run({ url: "/dashboard.html", method: 'GET', headers: {} });
+
+            expect(next).toHaveBeenCalled();
+            expect(res.ended).toBe(false);
+            expect(fetched).toHaveLength(0);
+        });
+
+        test("fetches the target named in the path", async function () {
+            stubFetch(redirectResponse(S3_URL));
+
+            await run(proxyReq(ENCODE_URL));
+
+            expect(fetched[0].url).toBe(ENCODE_URL);
+        });
+
+        test("keeps a query string on the target", async function () {
+            stubFetch(redirectResponse(S3_URL));
+
+            await run(proxyReq(`${ENCODE_URL}?token=abc`));
+
+            expect(fetched[0].url).toBe(`${ENCODE_URL}?token=abc`);
+        });
+
+        test("is generic — it proxies a host the client-side rule never rewrites", async function () {
+            stubFetch(redirectResponse(S3_URL));
+
+            await run(proxyReq("https://example.org/x.hic"));
+
+            expect(fetched[0].url).toBe("https://example.org/x.hic");
+        });
+
+    });
+
+    describe("the request it makes", function () {
+
+        beforeEach(() => stubFetch(redirectResponse(S3_URL)));
+
+        test("claims an allowlisted Origin", async function () {
+            await run(proxyReq(ENCODE_URL));
+
+            expect(fetched[0].init.headers.Origin).toBe(DEFAULT_ORIGIN);
+            expect(DEFAULT_ORIGIN).toBe("https://aidenlab.org");
+        });
+
+        test("honours a configured Origin", async function () {
+            await run(proxyReq(ENCODE_URL), { origin: "https://igv.org" });
+
+            expect(fetched[0].init.headers.Origin).toBe("https://igv.org");
+        });
+
+        // ENCODE returns 502 to an allowlisted Origin carrying a spoofed Chrome UA — measured
+        // 2026-08-02, see the note on REQUEST_HEADERS. Origin alone decides the challenge.
+        test("identifies itself honestly rather than impersonating a browser", async function () {
+            await run(proxyReq(ENCODE_URL));
+
+            const { headers } = fetched[0].init;
+            expect(headers['User-Agent']).toContain("juicebox.js-dev-proxy");
+            expect(headers['User-Agent']).not.toMatch(/Mozilla|Chrome|Safari|Gecko/);
+        });
+
+        test("sends the Sec-Fetch trio a browser's own cross-origin fetch would send", async function () {
+            await run(proxyReq(ENCODE_URL));
+
+            const { headers } = fetched[0].init;
+            expect(headers['Sec-Fetch-Site']).toBe("cross-site");
+            expect(headers['Sec-Fetch-Mode']).toBe("cors");
+            expect(headers['Sec-Fetch-Dest']).toBe("empty");
+        });
+
+        test("forwards the Range header — .hic reading is entirely byte-range based", async function () {
+            await run(proxyReq(ENCODE_URL, { range: "bytes=0-99" }));
+
+            expect(fetched[0].init.headers.Range).toBe("bytes=0-99");
+        });
+
+        test("does not forward the browser's own Origin, Host or Cookie", async function () {
+            await run(proxyReq(ENCODE_URL, {
+                origin: "http://localhost:3000",
+                host: "localhost:3000",
+                cookie: "session=secret"
+            }));
+
+            const { headers } = fetched[0].init;
+            expect(headers.Origin).toBe(DEFAULT_ORIGIN);
+            expect(headers.Host).toBeUndefined();
+            expect(headers.Cookie).toBeUndefined();
+        });
+
+        test("does not follow redirects itself", async function () {
+            await run(proxyReq(ENCODE_URL));
+
+            expect(fetched[0].init.redirect).toBe("manual");
+        });
+
+    });
+
+    describe("the redirect", function () {
+
+        test("is handed to the browser, which fetches S3 directly", async function () {
+            stubFetch(redirectResponse(S3_URL));
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.statusCode).toBe(307);
+            expect(res.headers.location).toBe(S3_URL);
+            expect(res.body).toBeUndefined();
+        });
+
+        test("leaves the redirect body unread, so no map bytes cross Node", async function () {
+            const response = redirectResponse(S3_URL);
+            stubFetch(response);
+
+            await run(proxyReq(ENCODE_URL));
+
+            expect(response.bodyUsed).toBe(false);
+        });
+
+        test("relays every redirect status, not just 307", async function () {
+            stubFetch(new Response(null, { status: 302, headers: { location: S3_URL } }));
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.statusCode).toBe(302);
+            expect(res.headers.location).toBe(S3_URL);
+        });
+
+    });
+
+    describe("a non-redirect response", function () {
+
+        test("relays status and body", async function () {
+            stubFetch(new Response("map bytes", { status: 206, headers: { 'content-range': 'bytes 0-8/100' } }));
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.statusCode).toBe(206);
+            expect(res.headers['content-range']).toBe("bytes 0-8/100");
+            expect(Buffer.from(res.body).toString()).toBe("map bytes");
+        });
+
+        test("relays the bot-challenge headers, so presentError can still read them", async function () {
+            stubFetch(new Response("<html>captcha</html>", {
+                status: 405,
+                headers: { 'x-amzn-waf-action': 'captcha', 'content-type': 'text/html' }
+            }));
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.statusCode).toBe(405);
+            expect(res.headers['x-amzn-waf-action']).toBe("captcha");
+            expect(res.headers['access-control-expose-headers']).toBe("*");
+        });
+
+        test("drops hop-by-hop headers that would describe the wrong body", async function () {
+            stubFetch(new Response("body", {
+                status: 200,
+                headers: { 'content-encoding': 'gzip', 'transfer-encoding': 'chunked', 'connection': 'keep-alive' }
+            }));
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.headers['content-encoding']).toBeUndefined();
+            expect(res.headers['transfer-encoding']).toBeUndefined();
+            expect(res.headers['connection']).toBeUndefined();
+        });
+
+    });
+
+    describe("failure", function () {
+
+        test("rejects a target that is not an absolute URL", async function () {
+            stubFetch(new Response("never"));
+
+            const { res } = await run({ url: `${PROXY_PREFIX}not-a-url`, method: 'GET', headers: {} });
+
+            expect(res.statusCode).toBe(400);
+            expect(fetched).toHaveLength(0);
+        });
+
+        test("rejects a non-http protocol", async function () {
+            stubFetch(new Response("never"));
+
+            const { res } = await run(proxyReq("file:///etc/passwd"));
+
+            expect(res.statusCode).toBe(400);
+            expect(fetched).toHaveLength(0);
+        });
+
+        test("rejects an empty target", async function () {
+            stubFetch(new Response("never"));
+
+            const { res } = await run({ url: PROXY_PREFIX, method: 'GET', headers: {} });
+
+            expect(res.statusCode).toBe(400);
+            expect(fetched).toHaveLength(0);
+        });
+
+        test("reports a failed fetch as a bad gateway", async function () {
+            global.fetch = vi.fn(async () => { throw new Error("getaddrinfo ENOTFOUND"); });
+
+            const { res } = await run(proxyReq(ENCODE_URL));
+
+            expect(res.statusCode).toBe(502);
+            expect(String(res.body)).toContain("ENOTFOUND");
+        });
+
+    });
+
+});

--- a/test/testUrlMapper.js
+++ b/test/testUrlMapper.js
@@ -1,0 +1,85 @@
+/**
+ * setUrlMapper is the seam a host app throws in development to route .hic reads through the dev
+ * proxy. It must be unset by default, so a host app that never calls it is unaffected.
+ * See issue #440 and docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const strawConfigs = [];
+
+vi.mock('hic-straw', () => ({
+    default: class Straw {
+        constructor(config) {
+            strawConfigs.push(config);
+            this.hicFile = {};
+        }
+    }
+}));
+
+const { setUrlMapper, getUrlMapper } = await import("../js/urlMapper.js");
+const { HiCDataset } = await import("../js/hicDataset.js");
+
+function strawConfigFor(config) {
+    strawConfigs.length = 0;
+    new HiCDataset(config);
+    return strawConfigs.at(-1);
+}
+
+describe("url mapper", function () {
+
+    beforeEach(() => {
+        strawConfigs.length = 0;
+    });
+
+    afterEach(() => {
+        setUrlMapper(undefined);
+    });
+
+    test("is unset by default", function () {
+        expect(getUrlMapper()).toBeUndefined();
+    });
+
+    test("leaves the straw config alone when unset", function () {
+        expect(strawConfigFor({ url: "https://example.org/x.hic" }).mapUrl).toBeUndefined();
+    });
+
+    test("reaches straw as config.mapUrl once set", function () {
+        const mapper = url => url;
+        setUrlMapper(mapper);
+
+        expect(strawConfigFor({ url: "https://example.org/x.hic" }).mapUrl).toBe(mapper);
+    });
+
+    test("preserves the rest of the config when it injects the mapper", function () {
+        setUrlMapper(url => url);
+
+        const config = strawConfigFor({ url: "https://example.org/x.hic", name: "x.hic" });
+
+        expect(config.url).toBe("https://example.org/x.hic");
+        expect(config.name).toBe("x.hic");
+    });
+
+    test("does not mutate the caller's config object", function () {
+        setUrlMapper(url => url);
+        const config = { url: "https://example.org/x.hic" };
+
+        new HiCDataset(config);
+
+        expect(config.mapUrl).toBeUndefined();
+    });
+
+    test("yields to a mapper the caller supplied explicitly", function () {
+        const explicit = url => url;
+        setUrlMapper(url => `${url}?module-scope`);
+
+        expect(strawConfigFor({ url: "https://example.org/x.hic", mapUrl: explicit }).mapUrl).toBe(explicit);
+    });
+
+    test("can be cleared", function () {
+        setUrlMapper(url => url);
+        setUrlMapper(undefined);
+
+        expect(strawConfigFor({ url: "https://example.org/x.hic" }).mapUrl).toBeUndefined();
+    });
+
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { versionPlugin } from './vite-plugin-version.js';
+import { devProxy } from './dev-proxy/plugin.js';
 
 // Plugin to suppress source map warnings for third-party dependencies
 // These warnings occur because igv-ui and igv reference CSS source maps that don't exist
@@ -71,6 +72,9 @@ export default defineConfig({
   },
   plugins: [
     versionPlugin(),
+    // Dev only (apply: 'serve'). Pairs with hic.setUrlMapper(devMapUrl) on the pages that load
+    // maps from a host that serves a bot challenge. See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+    devProxy(),
     viteStaticCopy({
       targets: [
         { src: 'css/img/*', dest: 'css/img', rename: { stripBase: true } },


### PR DESCRIPTION
Closes #440.

ENCODE fronts `www.encodeproject.org` with AWS WAF, which answers any `Origin` not on its allowlist with a CAPTCHA page under a misleading `405`. `localhost` is never allowlisted, so ENCODE-hosted maps cannot be loaded in development. Design and rationale: `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.

## Three pieces

- **`js/urlMapper.js`** — `setUrlMapper`, a module-scope mapper `HiCDataset` hands to `new Straw()` as `config.mapUrl` (hic-straw ≥ 4.0.0, aidenlab/hic-straw#49). Unset by default. The library cannot detect dev mode itself: consumers install from git, npm runs `prepare` → `vite build`, and `import.meta.env.DEV` is baked `false` at *juicebox.js's* build time. The switch has to be thrown from outside.
- **`dev-proxy/map-url.js`** — the client-side rule. Rewrites only hosts known to challenge, so a genuine CORS or permissions problem still surfaces in development exactly as it would in production.
- **`dev-proxy/plugin.js`** — an `apply: 'serve'` Vite plugin. Its middleware fetches the target with an allowlisted `Origin` and hands ENCODE's `307` back to the browser rather than following it, so the map bytes never cross Node and nothing here can corrupt a `206 Partial Content`. Generic across hosts, because targets arrive from session files and user paste and cannot be enumerated — only the client-side rule is host-scoped.

Plus packaging (`files`/`exports`), the plugin wired into this repo's `vite.config.js`, `dev/encode-dev-proxy.html` with three probes, a dashboard link, and README adoption docs.

## Adoption, in a host app

```js
// vite.config.js
import { devProxy } from 'juicebox.js/dev-proxy/plugin'
export default defineConfig({ plugins: [devProxy()] })
```
```js
// app startup
import { devMapUrl } from 'juicebox.js/dev-proxy/map-url'
if (import.meta.env.DEV) hic.setUrlMapper(devMapUrl)
```

## Verification

Against `ENCFF718AWL.hic` from the running dev server, not only in tests:

- the proxy answers `307`; following it lands on `encode-public.s3.amazonaws.com` with `206 Partial Content`
- a real `Straw().getMetaData()` through the whole chain returns 26 chromosomes / 10 resolutions
- clean `npm run build` — no `__hic-proxy` anywhere in `dist/`
- non-ENCODE hosts (4DN, NCBI FTP, Wasabi, `hicfiles`) are left untouched

45 new unit tests; full suite 271 passing.

## One correction to ADR-0001

The ADR said the proxy needs browser-like `User-Agent` / `Sec-Fetch-*` headers. Measured 2026-08-02, reproduced with both curl and Node `fetch`: an allowlisted `Origin` **plus a spoofed Chrome UA gets `502`** from awselb, while no UA, a Firefox UA and an honest UA all get `307`. `Origin` alone decides the challenge — the browser headers only made it *visible* during diagnosis, because the challenge fires on a browser UA from a non-allowlisted origin.

The proxy therefore identifies itself as `juicebox.js-dev-proxy`, which also sits better with the ADR's own reasoning about `Origin`: assert only your own identity. Full table recorded as a dated amendment in the ADR and on #440.

## Notes

- The middleware relays non-redirect responses with headers intact, so the plain-language bot-challenge error from #441/#442 still works through the proxy.
- A caller-supplied `config.mapUrl` takes precedence over the module-scope mapper. Not in the spec; it seemed the only sane precedence.
- Scope unchanged: `.hic` reads through hic-straw only. `igvxhr` and igv's 1D loaders remain out of scope.
- This is a **workaround with an expiry condition**. If ENCODE exempts `@@download` from the CAPTCHA rule, delete `dev-proxy/` entirely; `setUrlMapper` is generic and can stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)