### PR TITLE
Give the dev proxy per-host request headers (#451)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,11 +78,29 @@ sharing a track (`js/trackPair.js`).
 
 ## Data access
 
+**Gate** — the general term for a data host refusing the request a browser is
+able to make. Two are known, and they refuse for unrelated reasons: the *bot
+challenge* and the *User-Agent allowlist*. Say which gate you mean; a fix for
+one does nothing for the other.
+
 **Bot challenge** — a data host answering an automated request with a CAPTCHA
 page instead of the file. The known case is AWS WAF in front of
 `www.encodeproject.org`, which serves `X-Amzn-Waf-Action: captcha` under a
 misleading `405` status to any request whose `Origin` is not on ENCODE's
 allowlist. Say *bot challenge*, not "the 405" — the status code is a lie.
+
+**User-Agent allowlist** — the other gate: a host serving `403` unless the
+request carries a `User-Agent` it recognises. `hicfiles.s3.amazonaws.com` and
+`dnazoo.s3.amazonaws.com` match a case-sensitive prefix, `IGV` among them. No
+browser can pass it — `User-Agent` is a forbidden header name in the Fetch spec,
+so the value the client libraries set never leaves. Unrelated to CORS, and
+unrelated to bucket permissions; both were ruled out.
+
+**Gated bucket** — a host behind the User-Agent allowlist. Named separately from
+*challenged host* (behind the bot challenge) because the proxy treats them
+differently: a challenged host answers with a redirect the proxy hands back,
+while a gated bucket serves its object directly, making the dev server a real
+data path.
 
 **Origin allowlist** — the data provider's list of domains permitted to fetch
 without a bot challenge. ENCODE's, on ENCODE's infrastructure; not editable from
@@ -96,10 +114,19 @@ rewrite a `.hic` URL before it is fetched. Registered once by the host app via
 `setUrlMapper`; unset in production. The library cannot detect dev mode itself,
 because consumers get a production-baked `dist`. See `docs/adr/0001`.
 
-**Dev proxy** — the `apply: 'serve'` Vite plugin under `dev-proxy/` that fetches
-challenged hosts server-side with an allowlisted `Origin` and returns the
-redirect to the browser. Development only, `.hic` reads only, host-scoped. A
-workaround with an expiry condition, not architecture. See `docs/adr/0001`.
+**Dev proxy** — the `apply: 'serve'` Vite plugin under `dev-proxy/` that refetches
+gated hosts from Node, where the headers a browser cannot set are ours to
+choose. What it sends, and what comes back, depends on the gate: a challenged
+host gets an allowlisted `Origin` and answers with a redirect the proxy hands
+straight back to the browser; a gated bucket gets an `IGV`-prefixed `User-Agent`
+and streams its bytes through the dev server. Development only, `.hic` reads
+only, host-scoped. A workaround with an expiry condition, not architecture. See
+`docs/adr/0001`.
+
+**Claimed host** — a host the dev proxy routes, declared in `CHALLENGED_HOSTS`
+together with the headers its gate wants. Everything else fetches directly, on
+purpose: a genuine CORS or permissions failure has to stay visible in
+development.
 
 ## Architecture vocabulary
 

--- a/README.md
+++ b/README.md
@@ -159,11 +159,14 @@ This opens a dashboard at `http://localhost:3000` with links to all available pa
 
 Note: The Vite dev server is required because the source files use bare npm import specifiers and SCSS, which browsers cannot resolve from a plain static file server.
 
-## Loading maps from hosts that serve a bot challenge
+## Loading maps from hosts that refuse a browser
 
-Some data hosts — `www.encodeproject.org` today — put AWS WAF in front of their files and answer any origin not on their allowlist with a CAPTCHA page, under a misleading `405`. `localhost` is never allowlisted, so those maps cannot be loaded in development without help.
+Some data hosts refuse the request a browser is able to make, so their maps cannot be loaded in development without help. Two gates are known:
 
-`dev-proxy/` is a **development-only** workaround: a Vite plugin that fetches the file from Node with an allowlisted `Origin` and hands the resulting redirect back to the browser, plus the client-side rule that decides which hosts get routed that way. It is already wired into this repo's dev server — see `dev/encode-dev-proxy.html`. In a host application:
+- **A bot challenge keyed on `Origin`** — `www.encodeproject.org` puts AWS WAF in front of its files and answers any origin not on its allowlist with a CAPTCHA page, under a misleading `405`. `localhost` is never allowlisted.
+- **A `User-Agent` allowlist** — `hicfiles.s3.amazonaws.com` and `dnazoo.s3.amazonaws.com` serve `403` unless the request carries an allowlisted `User-Agent`. No browser can comply: `User-Agent` is a forbidden header name in the Fetch spec, so the value the client libraries set is dropped before the request leaves.
+
+`dev-proxy/` is a **development-only** workaround: a Vite plugin that refetches the file from Node, where those headers are ours to set, plus the client-side rule that decides which hosts get routed that way. It is already wired into this repo's dev server — see `dev/encode-dev-proxy.html`. In a host application:
 
 ```js
 // vite.config.js
@@ -180,9 +183,13 @@ import { devMapUrl } from 'juicebox.js/dev-proxy/map-url'
 if (import.meta.env.DEV) hic.setUrlMapper(devMapUrl)
 ```
 
-`devProxy()` takes an `origin` option (default `https://aidenlab.org`) — the `Origin` the proxy claims. Set it to a domain you actually control.
+`devProxy()` takes an `origin` option (default `https://aidenlab.org`) — the `Origin` the proxy claims for hosts whose gate keys on one. Set it to a domain you actually control.
 
-`apply: 'serve'` means the plugin can never enter a production build, and `setUrlMapper` is unset by default: a host app that never calls it behaves exactly as before. Only `.hic` reads through hic-straw are covered. See `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.
+Which hosts get routed, and what headers each is sent, are declared together in `CHALLENGED_HOSTS` in `dev-proxy/map-url.js`. Adding the next such host is an entry there and nothing else. Every other host keeps fetching directly, so a genuine CORS or permissions problem still surfaces in development exactly as it would in production.
+
+For the `Origin`-challenged host the proxy hands the redirect back and the file streams to the browser from storage directly. The `User-Agent`-gated buckets serve their objects with no redirect to hand back, so for those the dev server relays the bytes.
+
+`apply: 'serve'` means the plugin can never enter a production build, and `setUrlMapper` is unset by default: a host app that never calls it behaves exactly as before. Only `.hic` reads through hic-straw are covered — igv's track loaders are a separate transport, see issue #450. Details and measurements: `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.
 
 This creates a dist folder with the following files
 

--- a/dev-proxy/map-url.js
+++ b/dev-proxy/map-url.js
@@ -26,6 +26,15 @@
 const IGV_PREFIXED_USER_AGENT = 'IGV-juicebox.js-dev-proxy (+https://github.com/aidenlab/juicebox.js)'
 
 /**
+ * What the proxy must do differently for one host.
+ *
+ * @typedef {object} HostRule
+ * @property {boolean} [claimsOrigin] - assert the proxy's configured Origin, for a gate that keys
+ *           on one. The value itself is the plugin's to supply, not this module's.
+ * @property {Record<string, string>} [requestHeaders] - headers that override the shared set.
+ */
+
+/**
  * Hosts that refuse the request a browser is able to make, and what the proxy must do differently
  * for each. Adding a host here and nothing else is the whole fix for the next one.
  *
@@ -56,8 +65,11 @@ const CHALLENGED_HOSTS = {
  * hicfiles/…` — is deliberately left alone: that endpoint serves every bucket without a vhost
  * name, so claiming it would route strangers' data through the dev server.
  *
+ * `Object.hasOwn` rather than a plain lookup so that a host named after something on
+ * `Object.prototype` — `constructor`, `toString` — cannot match a rule that was never declared.
+ *
  * @param {string} host
- * @returns {{claimsOrigin?: boolean, requestHeaders?: Record<string, string>} | undefined}
+ * @returns {HostRule | undefined}
  */
 function ruleForHost(host) {
     return Object.hasOwn(CHALLENGED_HOSTS, host) ? CHALLENGED_HOSTS[host] : undefined

--- a/dev-proxy/map-url.js
+++ b/dev-proxy/map-url.js
@@ -18,10 +18,50 @@
  */
 
 /**
- * Hosts that answer a non-allowlisted Origin with a bot challenge. Adding a host here and nothing
- * else is the whole fix for the next one that starts challenging.
+ * The User-Agent the gated buckets accept. Their allowlist is a case-sensitive **prefix** match,
+ * measured 2026-08-03: `IGV`, `IGVX` and `IGV-dev-proxy` are all served, while `igv`, `Juicebox`,
+ * every browser value and an empty User-Agent are refused. The prefix is what the gate reads; the
+ * rest is there so the request still says who is really asking. See issue #451.
  */
-const CHALLENGED_HOSTS = new Set(['www.encodeproject.org'])
+const IGV_PREFIXED_USER_AGENT = 'IGV-juicebox.js-dev-proxy (+https://github.com/aidenlab/juicebox.js)'
+
+/**
+ * Hosts that refuse the request a browser is able to make, and what the proxy must do differently
+ * for each. Adding a host here and nothing else is the whole fix for the next one.
+ *
+ * Two gates are known, and they want opposite things — which is why the header set is a property
+ * of the host rather than one constant for every target:
+ *
+ *   `claimsOrigin`   AWS WAF answering a non-allowlisted `Origin` with a bot challenge. The proxy
+ *                    asserts an allowlisted Origin (the plugin's `origin` option) and identifies
+ *                    itself honestly — a spoofed browser User-Agent here draws a 502.
+ *
+ *   `requestHeaders` a `User-Agent` allowlist. `User-Agent` is a forbidden header name in the
+ *                    Fetch spec, so no browser can satisfy it however the client library asks;
+ *                    Node can. These hosts are not Origin-sensitive, so none is claimed for them.
+ *
+ * Note the asymmetry with the two gates' response shapes, which matters to the middleware: the
+ * Origin-challenged host answers with a redirect to signed storage, so its payload never crosses
+ * Node. These buckets serve the object directly, so for them the dev server really is the data
+ * path. Ranged reads are relayed as they arrive. See docs/adr/0001.
+ */
+const CHALLENGED_HOSTS = {
+    'www.encodeproject.org': { claimsOrigin: true },
+    'hicfiles.s3.amazonaws.com': { requestHeaders: { 'User-Agent': IGV_PREFIXED_USER_AGENT } },
+    'dnazoo.s3.amazonaws.com': { requestHeaders: { 'User-Agent': IGV_PREFIXED_USER_AGENT } }
+}
+
+/**
+ * Host-scoped by design. Path-style addressing of the same gated buckets — `s3.amazonaws.com/
+ * hicfiles/…` — is deliberately left alone: that endpoint serves every bucket without a vhost
+ * name, so claiming it would route strangers' data through the dev server.
+ *
+ * @param {string} host
+ * @returns {{claimsOrigin?: boolean, requestHeaders?: Record<string, string>} | undefined}
+ */
+function ruleForHost(host) {
+    return Object.hasOwn(CHALLENGED_HOSTS, host) ? CHALLENGED_HOSTS[host] : undefined
+}
 
 /**
  * The middleware's mount point. The target follows it verbatim, so a proxied read is legible in
@@ -76,7 +116,7 @@ function devMapUrl(url) {
 
     const parsed = parseHttpUrl(url)
 
-    return parsed && CHALLENGED_HOSTS.has(parsed.host) ? toProxyPath(url) : url
+    return parsed && ruleForHost(parsed.host) ? toProxyPath(url) : url
 }
 
-export { devMapUrl, parseHttpUrl, toProxyPath, targetFromProxyPath, PROXY_PREFIX }
+export { devMapUrl, parseHttpUrl, toProxyPath, targetFromProxyPath, ruleForHost, PROXY_PREFIX }

--- a/dev-proxy/plugin.js
+++ b/dev-proxy/plugin.js
@@ -15,7 +15,7 @@
  * See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
  */
 
-import { PROXY_PREFIX, parseHttpUrl, targetFromProxyPath } from './map-url.js'
+import { PROXY_PREFIX, parseHttpUrl, targetFromProxyPath, ruleForHost } from './map-url.js'
 
 /**
  * The Origin the proxy claims. aidenlab.org is this project's own domain and its own entry on
@@ -25,16 +25,21 @@ import { PROXY_PREFIX, parseHttpUrl, targetFromProxyPath } from './map-url.js'
 const DEFAULT_ORIGIN = 'https://aidenlab.org'
 
 /**
- * The proxy identifies itself honestly rather than impersonating a browser.
+ * What every proxied request sends, whichever host it is for.
  *
- * Measured against ENCODE on 2026-08-02, correcting the ADR as written: `Origin` alone decides the
- * challenge, and a spoofed Chrome User-Agent is actively harmful. With an allowlisted Origin, an
- * honest UA, a Firefox UA and no UA at all all return 307; `Chrome/126.0.0.0` returns **502** from
- * awselb, with or without the sec-ch-ua hints. The bot challenge itself fires on a browser UA with
- * a non-allowlisted Origin — which is what made the header set look load-bearing.
+ * The proxy identifies itself honestly rather than impersonating a browser. Measured against
+ * ENCODE on 2026-08-02, correcting the ADR as written: `Origin` alone decides the challenge, and a
+ * spoofed Chrome User-Agent is actively harmful. With an allowlisted Origin, an honest UA, a
+ * Firefox UA and no UA at all all return 307; `Chrome/126.0.0.0` returns **502** from awselb, with
+ * or without the sec-ch-ua hints. The bot challenge itself fires on a browser UA with a
+ * non-allowlisted Origin — which is what made the header set look load-bearing.
  *
  * The Sec-Fetch-* trio is what a browser's own cross-origin fetch would send and is verified
  * harmless; it stays so the proxied request resembles the request being stood in for.
+ *
+ * A host whose gate wants something else overrides it in CHALLENGED_HOSTS, next to the rule that
+ * decides the host is claimed at all. The two known gates want opposite User-Agents, so this can
+ * never be one global set again.
  */
 const REQUEST_HEADERS = {
     'User-Agent': 'juicebox.js-dev-proxy (+https://github.com/aidenlab/juicebox.js)',
@@ -42,6 +47,37 @@ const REQUEST_HEADERS = {
     'Sec-Fetch-Site': 'cross-site',
     'Sec-Fetch-Mode': 'cors',
     'Sec-Fetch-Dest': 'empty'
+}
+
+/**
+ * The rule for a target the client-side mapper never claims. The middleware is generic — targets
+ * arrive from session files and user paste — so an unknown host keeps the behaviour it had before
+ * per-host rules existed: the shared header set, with an Origin claimed.
+ */
+const DEFAULT_RULE = { claimsOrigin: true }
+
+/**
+ * @param {URL} target
+ * @param {string} origin - the Origin the proxy claims, for hosts whose gate keys on one.
+ * @param {object} reqHeaders - the browser's own headers. Only Range is forwarded: its Origin is
+ *        the very thing that gets challenged, and its Host and Cookie belong to the dev server.
+ * @returns {Record<string, string>}
+ */
+function requestHeadersFor(target, origin, reqHeaders) {
+
+    const rule = ruleForHost(target.host) || DEFAULT_RULE
+
+    const headers = { ...REQUEST_HEADERS, ...rule.requestHeaders }
+
+    if (rule.claimsOrigin) {
+        headers.Origin = origin
+    }
+
+    if (reqHeaders?.range) {
+        headers.Range = reqHeaders.range
+    }
+
+    return headers
 }
 
 /**
@@ -70,18 +106,13 @@ function createProxyMiddleware({ origin = DEFAULT_ORIGIN } = {}) {
         }
 
         const target = targetFromProxyPath(req.url)
+        const parsedTarget = parseHttpUrl(target)
 
-        if (!parseHttpUrl(target)) {
+        if (!parsedTarget) {
             return fail(res, 400, `hic dev proxy: not an absolute http(s) URL — ${target}`)
         }
 
-        // Only Range is forwarded from the browser. Everything else is ours: forwarding the
-        // browser's Origin is the very thing that gets challenged, and its Host and Cookie belong
-        // to the dev server, not to the data host.
-        const headers = { ...REQUEST_HEADERS, Origin: origin }
-        if (req.headers?.range) {
-            headers.Range = req.headers.range
-        }
+        const headers = requestHeadersFor(parsedTarget, origin, req.headers)
 
         let response
         try {

--- a/dev-proxy/plugin.js
+++ b/dev-proxy/plugin.js
@@ -15,6 +15,8 @@
  * See docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
  */
 
+import { once } from 'node:events'
+
 import { PROXY_PREFIX, parseHttpUrl, targetFromProxyPath, ruleForHost } from './map-url.js'
 
 /**
@@ -53,6 +55,8 @@ const REQUEST_HEADERS = {
  * The rule for a target the client-side mapper never claims. The middleware is generic — targets
  * arrive from session files and user paste — so an unknown host keeps the behaviour it had before
  * per-host rules existed: the shared header set, with an Origin claimed.
+ *
+ * @type {import('./map-url.js').HostRule}
  */
 const DEFAULT_RULE = { claimsOrigin: true }
 
@@ -136,18 +140,31 @@ function createProxyMiddleware({ origin = DEFAULT_ORIGIN } = {}) {
             return res.end()
         }
 
-        // Anything else is a small payload in practice — a bot challenge page or another error,
-        // since the challenged hosts answer a successful read with a redirect. Buffering keeps the
-        // relay simple and lets Node set an accurate Content-Length.
-        let body
-        try {
-            body = Buffer.from(await response.arrayBuffer())
-        } catch (e) {
-            return fail(res, 502, `hic dev proxy: ${e.message}`)
-        }
+        // Anything else is relayed as it arrives. For the Origin-challenged host this is only ever
+        // a small payload — a bot challenge page or another error — because a successful read
+        // there is the redirect above. The User-Agent-gated buckets have no redirect to hand back,
+        // so this is their data path: an object here runs to gigabytes, and reading one into a
+        // Buffer first would put all of it in the dev server's memory at once.
         relayHeaders(response, res)
         res.statusCode = response.status
-        res.end(body)
+
+        if (!response.body) {
+            return res.end()
+        }
+
+        try {
+            for await (const chunk of response.body) {
+                if (res.write(chunk) === false) {
+                    await once(res, 'drain')
+                }
+            }
+        } catch (e) {
+            // Headers and status are already on the wire, so there is no status left to set. End
+            // the truncated response and let the caller's parse fail rather than hanging it.
+            console.error(`hic dev proxy: ${target} — ${e.message}`)
+        }
+
+        res.end()
     }
 }
 

--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -191,6 +191,73 @@ Why the 502 rather than a challenge is a guess — most likely a WAF rule on a
 Chrome `User-Agent` unaccompanied by the rest of a real Chrome fingerprint. It is
 ENCODE's rule to change, so pin nothing to it beyond "do not impersonate".
 
+## Amendment, 2026-08-03 — a second gate, and the proxy becomes a data path
+
+Issue #451. Adopting the proxy across `dev/` turned up hosts that refuse a
+browser for an entirely different reason, and accommodating them changes one of
+the properties claimed above.
+
+### The gate
+
+`hicfiles.s3.amazonaws.com` and `dnazoo.s3.amazonaws.com` gate on `User-Agent`.
+It is an allowlist matched **case-sensitively against the start of the string**,
+measured 2026-08-03 against `combined_peaks.txt`, every value probed twice:
+
+| `User-Agent` | Result |
+|---|---|
+| `IGV`, `IGVX`, `IGV/2.19.1`, `IGV-dev-proxy` | 200 |
+| `python-requests`, `python-requests/2.31`, `python-requests/9.9` | 200 |
+| `igv` (lowercase), `IG`, `aIGV`, `python`, `requests` | 403 |
+| `Juicebox`, `juicebox.js-dev-proxy IGV`, `foo`, `x` | 403 |
+| `Mozilla/5.0`, `Mozilla`, `AppleWebKit`, `Safari`, `curl/8.7.1` | 403 |
+| *(absent)* | 403 |
+
+No browser can satisfy this: `User-Agent` is a forbidden header name in the Fetch
+spec, so the `IGV` value hic-straw and igv.js set is silently dropped. curl and
+Node succeed; the browser cannot. Upstream: aidenlab/hic-straw#46.
+
+CORS is **not** a factor here and should not be re-investigated — with an
+`Origin` present these buckets return `Access-Control-Allow-Origin: *` on both
+200 and 206, for `localhost:3000` and `aidenlab.org` alike. This is unrelated to
+#444, which concerns `hicfiles.json` on a different host.
+
+### What changed
+
+Request headers are now a **per-host** property, declared in `CHALLENGED_HOSTS`
+next to the rule that decides a host is claimed at all. This had to stop being
+one global set: the two gates want opposite things, and the `IGV` prefix that
+fixes these buckets would sit alongside an `Origin` the other gate reads. An
+unclaimed host keeps the original header set unchanged.
+
+The proxy sends `IGV-juicebox.js-dev-proxy (+…)`. The prefix is what the gate
+reads; the remainder keeps faith with "assert only your own identity" above —
+the proxy satisfies the allowlist without claiming to *be* IGV, which the
+measurements show is unnecessary.
+
+### The property this costs
+
+**"Only the small redirect request crosses Node; the map bytes do not" is no
+longer true for every host.** It remains true for ENCODE, which answers with a
+`307` to signed S3. These buckets serve the object **directly** — `206`,
+`Content-Range`, no `Location`. There is nothing to redirect to, so for them the
+dev server really is the data path and every ranged read is relayed through it.
+`combined.hic` there is 11.7 GB; a session touches only ranges of it, but all of
+them cross Node.
+
+Accepted knowingly, dev-only, and preferred over the alternative: these are the
+project's own buckets, so the honest fix is to loosen the gate at the host — but
+that needs AWS admin access rather than a commit, and would not help anyone
+running an older juicebox. The relay must therefore never buffer a whole object,
+and must preserve status and `Content-Range` exactly.
+
+### Not claimed
+
+Path-style addressing of the same buckets (`s3.amazonaws.com/hicfiles/…`) is
+left fetching directly. The rule is host-scoped, and that endpoint serves every
+bucket without a vhost name; claiming it would route strangers' data through the
+dev server. A fixture using the path-style form stays unreachable in development
+— repoint it at the vhost form.
+
 ## Reversal
 
 This is a **workaround with an expiry condition**, unlike the hic-straw ADR it

--- a/test/testDevMapUrl.js
+++ b/test/testDevMapUrl.js
@@ -9,11 +9,30 @@ import { describe, test, expect } from 'vitest';
 import { devMapUrl, targetFromProxyPath, PROXY_PREFIX } from "../dev-proxy/map-url.js";
 
 const ENCODE_URL = "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic";
+const HICFILES_URL = "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic";
+const DNAZOO_URL = "https://dnazoo.s3.amazonaws.com/Phascolarctos_cinereus/phaCin_unsw_v4.1.rawchrom.hic";
 
 describe("devMapUrl", function () {
 
     test("routes a challenged host through the proxy", function () {
         expect(devMapUrl(ENCODE_URL)).toBe(`${PROXY_PREFIX}${ENCODE_URL}`);
+    });
+
+    describe("routes both gates, not just the Origin one", function () {
+
+        // These two refuse any browser: they gate on User-Agent, which the Fetch spec forbids a
+        // browser from setting, so the value the client libraries ask for is silently dropped.
+        const gated = {
+            "a User-Agent-gated bucket": HICFILES_URL,
+            "the assembly bucket behind the same gate": DNAZOO_URL,
+        };
+
+        for (const [label, url] of Object.entries(gated)) {
+            test(label, function () {
+                expect(devMapUrl(url)).toBe(`${PROXY_PREFIX}${url}`);
+            });
+        }
+
     });
 
     test("keeps the target URL whole, so the middleware can read it back", function () {
@@ -38,6 +57,9 @@ describe("devMapUrl", function () {
             "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/x.hic",
             "https://ftp.ncbi.nlm.nih.gov/geo/samples/x.hic",
             "https://s3.us-east-1.wasabisys.com/x.hic",
+            // Path-style addressing of the same gated bucket. Deliberately not claimed: the rule
+            // is host-scoped, and s3.amazonaws.com is a shared endpoint serving every bucket that
+            // has no vhost name. Claiming it would route strangers' data through the dev server.
             "https://s3.amazonaws.com/hicfiles/x.hic",
             "https://dl.dropboxusercontent.com/s/x.hic",
             "https://encodeproject.org.evil.example/x.hic",

--- a/test/testDevMapUrl.js
+++ b/test/testDevMapUrl.js
@@ -57,9 +57,7 @@ describe("devMapUrl", function () {
             "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/x.hic",
             "https://ftp.ncbi.nlm.nih.gov/geo/samples/x.hic",
             "https://s3.us-east-1.wasabisys.com/x.hic",
-            // Path-style addressing of the same gated bucket. Deliberately not claimed: the rule
-            // is host-scoped, and s3.amazonaws.com is a shared endpoint serving every bucket that
-            // has no vhost name. Claiming it would route strangers' data through the dev server.
+            // Path-style addressing of a gated bucket, deliberately not claimed — see ruleForHost.
             "https://s3.amazonaws.com/hicfiles/x.hic",
             "https://dl.dropboxusercontent.com/s/x.hic",
             "https://encodeproject.org.evil.example/x.hic",

--- a/test/testDevProxyMiddleware.js
+++ b/test/testDevProxyMiddleware.js
@@ -12,6 +12,7 @@ import { PROXY_PREFIX } from "../dev-proxy/map-url.js";
 
 const ENCODE_URL = "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic";
 const S3_URL = "https://encode-public.s3.amazonaws.com/2020/x.hic?X-Amz-Signature=abc";
+const HICFILES_URL = "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic";
 
 let fetched;
 
@@ -160,6 +161,62 @@ describe("dev proxy middleware", function () {
             await run(proxyReq(ENCODE_URL));
 
             expect(fetched[0].init.redirect).toBe("manual");
+        });
+
+    });
+
+    // The second gate. These buckets answer 403 to every browser User-Agent and to the proxy's
+    // own honest one; the allowlist is a case-sensitive prefix match, and `IGV` is on it. Measured
+    // 2026-08-03, see issue #451 — `IGV-dev-proxy` passes, so the proxy can satisfy the gate while
+    // still naming itself.
+    describe("a User-Agent-gated host", function () {
+
+        beforeEach(() => stubFetch(new Response("bytes", { status: 206 })));
+
+        test("is sent a User-Agent the allowlist accepts", async function () {
+            await run(proxyReq(HICFILES_URL));
+
+            expect(fetched[0].init.headers['User-Agent']).toMatch(/^IGV/);
+        });
+
+        test("is still told who is really asking", async function () {
+            await run(proxyReq(HICFILES_URL));
+
+            const userAgent = fetched[0].init.headers['User-Agent'];
+            expect(userAgent).toContain("juicebox.js-dev-proxy");
+            expect(userAgent).not.toMatch(/Mozilla|Chrome|Safari|Gecko/);
+        });
+
+        test("is not sent an Origin — this gate does not key on one", async function () {
+            await run(proxyReq(HICFILES_URL));
+
+            expect(fetched[0].init.headers.Origin).toBeUndefined();
+        });
+
+        test("keeps the shared header set", async function () {
+            await run(proxyReq(HICFILES_URL, { range: "bytes=0-99" }));
+
+            const { headers } = fetched[0].init;
+            expect(headers['Sec-Fetch-Site']).toBe("cross-site");
+            expect(headers.Accept).toBe("*/*");
+            expect(headers.Range).toBe("bytes=0-99");
+        });
+
+        test("does not leak its User-Agent to the Origin-challenged host", async function () {
+            await run(proxyReq(ENCODE_URL));
+
+            // ENCODE returns 502 to an allowlisted Origin carrying a spoofed Chrome UA, so its
+            // header set is load-bearing and must stay exactly as it was.
+            expect(fetched[0].init.headers['User-Agent']).not.toMatch(/^IGV/);
+            expect(fetched[0].init.headers.Origin).toBe(DEFAULT_ORIGIN);
+        });
+
+        test("leaves an unclaimed host on the default header set", async function () {
+            await run(proxyReq("https://example.org/x.hic"));
+
+            const { headers } = fetched[0].init;
+            expect(headers['User-Agent']).not.toMatch(/^IGV/);
+            expect(headers.Origin).toBe(DEFAULT_ORIGIN);
         });
 
     });

--- a/test/testDevProxyMiddleware.js
+++ b/test/testDevProxyMiddleware.js
@@ -16,17 +16,31 @@ const HICFILES_URL = "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/c
 
 let fetched;
 
+/**
+ * Stands in for a node ServerResponse. `write` accepts chunks the way the real thing does, so a
+ * relayed body arrives here in the same pieces the middleware wrote it in — which is how the tests
+ * can tell a streamed relay from a buffered one.
+ */
 function fakeRes() {
     return {
         statusCode: undefined,
         headers: {},
-        body: undefined,
+        chunks: [],
         ended: false,
+        get body() {
+            return this.chunks.length > 0 ? Buffer.concat(this.chunks.map(Buffer.from)) : undefined;
+        },
         setHeader(name, value) {
             this.headers[name.toLowerCase()] = value;
         },
+        write(chunk) {
+            this.chunks.push(chunk);
+            return true;
+        },
         end(body) {
-            this.body = body;
+            if (body !== undefined) {
+                this.chunks.push(body);
+            }
             this.ended = true;
         }
     };
@@ -202,16 +216,22 @@ describe("dev proxy middleware", function () {
             expect(headers.Range).toBe("bytes=0-99");
         });
 
-        test("does not leak its User-Agent to the Origin-challenged host", async function () {
+    });
+
+    // One host's rule must never reach another's request: the two gates want opposite things, and
+    // a User-Agent that satisfies the buckets is exactly the kind ENCODE answers 502 to.
+    describe("rules stay scoped to the host they belong to", function () {
+
+        beforeEach(() => stubFetch(new Response("bytes", { status: 206 })));
+
+        test("the Origin-challenged host keeps its own header set", async function () {
             await run(proxyReq(ENCODE_URL));
 
-            // ENCODE returns 502 to an allowlisted Origin carrying a spoofed Chrome UA, so its
-            // header set is load-bearing and must stay exactly as it was.
             expect(fetched[0].init.headers['User-Agent']).not.toMatch(/^IGV/);
             expect(fetched[0].init.headers.Origin).toBe(DEFAULT_ORIGIN);
         });
 
-        test("leaves an unclaimed host on the default header set", async function () {
+        test("an unclaimed host keeps the default header set", async function () {
             await run(proxyReq("https://example.org/x.hic"));
 
             const { headers } = fetched[0].init;
@@ -263,6 +283,28 @@ describe("dev proxy middleware", function () {
             expect(res.statusCode).toBe(206);
             expect(res.headers['content-range']).toBe("bytes 0-8/100");
             expect(Buffer.from(res.body).toString()).toBe("map bytes");
+        });
+
+        // The User-Agent-gated buckets have no redirect to hand back, so this is their data path
+        // and objects on them run to gigabytes. Reading one whole before writing any of it would
+        // put all of it in the dev server's memory — see the 2026-08-03 amendment in ADR 0001.
+        test("relays the body as it arrives rather than buffering it whole", async function () {
+            const chunks = ["first ", "second ", "third"];
+            stubFetch(new Response(new ReadableStream({
+                start(controller) {
+                    for (const chunk of chunks) {
+                        controller.enqueue(new TextEncoder().encode(chunk));
+                    }
+                    controller.close();
+                }
+            }), { status: 206, headers: { 'content-range': 'bytes 0-17/11694074933' } }));
+
+            const { res } = await run(proxyReq(HICFILES_URL, { range: "bytes=0-17" }));
+
+            expect(res.chunks).toHaveLength(chunks.length);
+            expect(res.body.toString()).toBe(chunks.join(""));
+            expect(res.headers['content-range']).toBe("bytes 0-17/11694074933");
+            expect(res.statusCode).toBe(206);
         });
 
         test("relays the bot-challenge headers, so presentError can still read them", async function () {


### PR DESCRIPTION
Closes #451.

The proxy sent one fixed header set to every target, tuned for ENCODE's Origin-keyed bot challenge. The `IGV`-`User-Agent` buckets — `hicfiles`, `dnazoo` — refuse it, so they stayed unreachable in development whether or not their URLs were routed. `User-Agent` is a forbidden header name in the Fetch spec, so no browser can satisfy that gate however the client library asks; Node can.

Request headers become a property of the host, declared in `CHALLENGED_HOSTS` beside the rule that decides the host is claimed. This had to stop being one global set: the two gates want opposite things, and a spoofed browser UA draws **502** from ENCODE. An unclaimed host keeps the original header set.

The UA sent is `IGV-juicebox.js-dev-proxy (+…)`. The gate is a case-sensitive **prefix** allowlist — measured, table in the ADR — so the prefix satisfies it while the remainder still says who is really asking. The proxy need not claim to be IGV.

## What this costs, and why the ADR changed

ADR 0001 claimed no payload ever crosses Node. That now holds **only for ENCODE**, which answers with a `307` to signed S3. These buckets serve their objects directly — `206`, `Content-Range`, no `Location` — so for them the dev server is a real data path.

Review of the first commit caught that the amendment said bytes are relayed as they arrive while the middleware still did `Buffer.from(await response.arrayBuffer())`. Fixed in the code rather than retracted in the prose: an un-ranged GET of the 11.7 GB `combined.hic` would have buffered all of it in the dev server. The relay now writes each chunk as it arrives, honouring backpressure, and a test counts the writes so the claim cannot rot silently again.

## Verification

Through the running dev server:

| Request | Result |
|---|---|
| hicfiles `.hic`, two different ranges | `206`, intact `Content-Range` |
| a proxied range vs. the same range read directly with an accepted UA | **hash-identical** |
| hicfiles 2D `.txt` (1.7 MB, multi-chunk) | `200`, 1,778,951 bytes |
| dnazoo `.hic` | `206` |
| ENCODE `.hic` (regression) | `307`, unchanged |

280 unit tests pass. **Not loaded in a browser.**

## Two things for the reviewer

1. **The brief's 2D-track acceptance criterion is not met here and cannot be** — 2D tracks read through `igvxhr.loadString` in `Track2D.loadTrack2D`, which never consults the mapper. That routing is #450. What this delivers is that such a track *succeeds once routed*.
2. **An unclaimed host still gets an `Origin` claimed.** The brief said the `origin` option applies to the Origin-challenged host only; the middleware is generic and its default rule keeps claiming one, preserving pre-change behaviour for targets arriving from session files or paste. Deliberate, documented at `DEFAULT_RULE`, flagged rather than silently diverged. Easy to change if you want unlisted hosts to get none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)