### PR TITLE
Route track reads through the registered URL mapper (#450)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,18 +109,26 @@ apps work and localhost does not. It keys on the `Origin` header — the domain 
 the page making the request — and has nothing to do with where anything is
 hosted.
 
-**URL mapper** — the function juicebox hands to hic-straw as `config.mapUrl` to
-rewrite a `.hic` URL before it is fetched. Registered once by the host app via
-`setUrlMapper`; unset in production. The library cannot detect dev mode itself,
-because consumers get a production-baked `dist`. See `docs/adr/0001`.
+**URL mapper** — the function juicebox applies to a data URL before it is
+fetched: handed to hic-straw as `config.mapUrl` for a `.hic` read, applied at the
+fetch for a 2D annotation, and written into the config for a 1D track, since igv
+reads those through loaders juicebox cannot reach into. Registered once by the
+host app via `setUrlMapper`; unset in production. The library cannot detect dev
+mode itself, because consumers get a production-baked `dist`. See
+`docs/adr/0001`.
+
+**Unmapped URL** — a track config's pre-mapping URL, carried alongside the mapped
+one so `toJSON` can serialize the original. The 1D rewrite is the only one that
+touches a config, and a session must never name the dev server.
 
 **Dev proxy** — the `apply: 'serve'` Vite plugin under `dev-proxy/` that refetches
 gated hosts from Node, where the headers a browser cannot set are ours to
 choose. What it sends, and what comes back, depends on the gate: a challenged
 host gets an allowlisted `Origin` and answers with a redirect the proxy hands
 straight back to the browser; a gated bucket gets an `IGV`-prefixed `User-Agent`
-and streams its bytes through the dev server. Development only, `.hic` reads
-only, host-scoped. A workaround with an expiry condition, not architecture. See
+and streams its bytes through the dev server. Development only, host-scoped,
+covering `.hic` and track reads. A workaround with an expiry condition, not
+architecture. See
 `docs/adr/0001`.
 
 **Claimed host** — a host the dev proxy routes, declared in `CHALLENGED_HOSTS`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,8 +118,8 @@ mode itself, because consumers get a production-baked `dist`. See
 `docs/adr/0001`.
 
 **Unmapped URL** — a track config's pre-mapping URL, carried alongside the mapped
-one so `toJSON` can serialize the original. The 1D rewrite is the only one that
-touches a config, and a session must never name the dev server.
+one so `HICBrowser.toJSON` can serialize the original. The 1D rewrite is the only
+one that touches a config, and a session must never name the dev server.
 
 **Dev proxy** — the `apply: 'serve'` Vite plugin under `dev-proxy/` that refetches
 gated hosts from Node, where the headers a browser cannot set are ours to

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Which hosts get routed, and what headers each is sent, are declared together in 
 
 For the `Origin`-challenged host the proxy hands the redirect back and the file streams to the browser from storage directly. The `User-Agent`-gated buckets serve their objects with no redirect to hand back, so for those the dev server relays the bytes.
 
-`apply: 'serve'` means the plugin can never enter a production build, and `setUrlMapper` is unset by default: a host app that never calls it behaves exactly as before. Only `.hic` reads through hic-straw are covered — igv's track loaders are a separate transport, see issue #450. Details and measurements: `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.
+`apply: 'serve'` means the plugin can never enter a production build, and `setUrlMapper` is unset by default: a host app that never calls it behaves exactly as before.
+
+The mapper covers `.hic` reads through hic-straw, 2D annotations, and 1D tracks read by igv. A 1D track is the awkward one: igv reads it through its own bundled loaders, which juicebox cannot reach into, so the mapped URL has to go into the config igv is handed. It never escapes from there — `browser.toJSON()` serializes the original, so a session saved in development loads in production. Still uncovered: gene search and session-file reads. Details and measurements: `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`.
 
 This creates a dist folder with the following files
 

--- a/dev/encode-dev-proxy.html
+++ b/dev/encode-dev-proxy.html
@@ -25,7 +25,7 @@
 
 <body>
 
-<h1>issue #440 — dev proxy for WAF-protected hosts</h1>
+<h1>issues #440, #450 — dev proxy for WAF-protected hosts</h1>
 <p class="sub">
     Checks the acceptance items that cannot be unit tests, because a bot challenge keys on
     <code>Origin</code> and only a browser at <code>localhost</code> sends the failing one. This page
@@ -73,6 +73,20 @@
     <div id="browser-container"></div>
 </div>
 
+<!-- ------------------------------------------------------------------ -->
+<div class="probe">
+    <h2>4. ENCODE-hosted tracks load, and stay out of the session — <span id="verdict-4" class="verdict pending">not run</span></h2>
+    <p>
+        Issue #450's acceptance criteria. Loads a bigWig (1D, read by igv's own loaders) and a
+        <code>.bedpe</code> (2D, read by juicebox) from the same challenged host onto the map from
+        probe 3, then checks <code>browser.toJSON()</code>. Both must render, and neither may
+        contribute a <code>/__hic-proxy/</code> path to the session — a session saved in development
+        has to load in production. Run probe 3 first.
+    </p>
+    <button id="run-4">Run</button>
+    <pre id="out-4">—</pre>
+</div>
+
 <script type="module">
 
     import hic from '../js/index.js'
@@ -84,6 +98,14 @@
 
     // Blocked from any non-allowlisted Origin, localhost included.
     const ENCODE_URL = 'https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic'
+
+    // Same host, same gate, same assembly (hg19) as the map above. The bigWig goes through igv's
+    // own loaders; the bedpe through juicebox's. Issue #450.
+    const ENCODE_BIGWIG_URL = 'https://www.encodeproject.org/files/ENCFF144KUK/@@download/ENCFF144KUK.bigWig'
+    const ENCODE_BEDPE_URL = 'https://www.encodeproject.org/files/ENCFF303QCX/@@download/ENCFF303QCX.bedpe.gz'
+
+    // Probe 3 makes the browser probe 4 loads tracks onto.
+    let browser
 
     const setVerdict = (n, pass, label) => {
         const el = document.getElementById(`verdict-${n}`)
@@ -176,7 +198,7 @@
         container.innerHTML = ''
 
         try {
-            const browser = await hic.createBrowser(container, {url: ENCODE_URL, name: 'ENCFF718AWL.hic'})
+            browser = await hic.createBrowser(container, {url: ENCODE_URL, name: 'ENCFF718AWL.hic'})
             setVerdict(3, true)
             report(3, [
                 `genome        ${browser.dataset.genomeId}`,
@@ -196,6 +218,68 @@
                 e.headers?.get('x-amzn-waf-action') === 'captcha'
                     ? 'FAIL — still challenged. The proxy Origin is not on the allowlist, or the read did not go through the mapper.'
                     : 'FAIL — see the message above.',
+            ])
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Tracks on the challenged host load, and the session stays clean
+    // ------------------------------------------------------------------
+    document.getElementById('run-4').onclick = async () => {
+
+        if (!browser) {
+            setVerdict(4, false)
+            report(4, ['No browser. Run probe 3 first — probe 4 loads tracks onto that map.'])
+            return
+        }
+
+        report(4, ['loading…'])
+
+        const tracks1DBefore = browser.trackPairs.length
+        const tracks2DBefore = browser.tracks2D.length
+
+        try {
+            await browser.loadTracks([
+                {url: ENCODE_BIGWIG_URL, name: 'ENCFF144KUK.bigWig'},
+                {url: ENCODE_BEDPE_URL, name: 'ENCFF303QCX.bedpe.gz'}
+            ])
+
+            const loaded1D = browser.trackPairs.length > tracks1DBefore
+            const loaded2D = browser.tracks2D.length > tracks2DBefore
+
+            // The constraint that makes this more than a load: toJSON copies config URLs verbatim,
+            // so a config-time rewrite would bake a dev-server path into every saved session.
+            const session = browser.toJSON()
+            const sessionUrls = (session.tracks || []).map(t => t.url)
+            const leaked = sessionUrls.filter(url => typeof url === 'string' && url.includes(PROXY_PREFIX))
+            const bothSerialized = sessionUrls.includes(ENCODE_BIGWIG_URL) && sessionUrls.includes(ENCODE_BEDPE_URL)
+
+            const pass = loaded1D && loaded2D && leaked.length === 0 && bothSerialized
+
+            setVerdict(4, pass)
+            report(4, [
+                `1D tracks     ${tracks1DBefore} -> ${browser.trackPairs.length}`,
+                `2D tracks     ${tracks2DBefore} -> ${browser.tracks2D.length}`,
+                '',
+                'session track urls:',
+                ...sessionUrls.map(url => `  ${url}`),
+                '',
+                pass
+                    ? 'PASS — both tracks loaded through the proxy and the session carries the original urls.'
+                    : !loaded1D
+                        ? 'FAIL — the bigWig did not load. Check the alert and the network panel: the request should be a /__hic-proxy/ path.'
+                        : !loaded2D
+                            ? 'FAIL — the bedpe did not load.'
+                            : leaked.length > 0
+                                ? `FAIL — a proxy path leaked into the session: ${leaked.join(', ')}. A session saved here would not load in production.`
+                                : 'FAIL — a track loaded but did not reach the session at its original url.',
+            ])
+        } catch (e) {
+            setVerdict(4, false)
+            report(4, [
+                `message   ${e.message || '(empty)'}`,
+                `code      ${e.code === undefined ? '(absent)' : e.code}`,
+                `waf       ${e.headers?.get('x-amzn-waf-action') || '(absent)'}`,
             ])
         }
     }

--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -134,6 +134,8 @@ would break juicebox outright, since `.hic` reading is entirely byte-range based
 and igv's own 1D track loaders are different transports with no equivalent seam;
 covering them would need a second mechanism. Out of scope until it actually bites.
 
+*(Superseded by the 2026-08-03 amendment on track reads, below — it bit.)*
+
 ### Making the failure legible — ships to production
 
 `presentError` (`js/utils.js`) already translates HTTP status into human text and
@@ -257,6 +259,57 @@ left fetching directly. The rule is host-scoped, and that endpoint serves every
 bucket without a vhost name; claiming it would route strangers' data through the
 dev server. A fixture using the path-style form stays unreachable in development
 — repoint it at the vhost form.
+
+## Amendment, 2026-08-03 — the mapper reaches track reads
+
+Issue #450. The scope above — `.hic` only — did not survive first contact: an
+ENCODE-hosted map loads while an ENCODE-hosted 1D track from the same session
+does not. The proxy middleware was never the problem; it is host-generic and
+already serves a bigWig correctly. Nothing routed track reads into it.
+
+The two track transports need different treatment, and the difference is the
+whole substance of this amendment.
+
+**2D annotations** are read by juicebox itself, at `Track2D.loadTrack2D`. Our
+call site, so the mapper is applied **at the fetch**: the mapped URL is used and
+discarded, `config.url` stays original, and `toJSON` needs no change at all.
+
+**1D tracks** are handed to `igv.createTrack` and read by igv's own bundled
+`igvxhr`, whose URL rewriting is a module-private function — `igv.esm.js` ships
+three copies of it, so patching the `igv-utils` dependency does not reach them.
+`igv.setCORSProxy` cannot substitute: its retry is gated on `xhr.status === 0`
+or `onerror`, and ENCODE's `405` carries valid CORS headers, so `onload` runs and
+goes straight to the error path. The retry is never reached.
+
+That leaves exactly one lever — **the `url` in the config igv is handed**. So for
+1D tracks the rewrite is config-time, which is the thing the `.hic` path was able
+to avoid.
+
+### The constraint that shapes it
+
+`HiCBrowser.toJSON` copies `config.url` verbatim. A config-time rewrite with no
+counterpart would therefore bake `/__hic-proxy/…` into **saved sessions** —
+a session saved in development would not load in production, and would name a
+machine that is not there. Any config-time mapping owes a matching un-map on
+serialization.
+
+`mapTrackConfig` writes the mapped URLs onto a **copy** of the config and carries
+the original in `unmappedUrl` alongside; `toJSON` reads through `unmappedUrl`.
+When no mapper is registered, or the mapper claims neither URL, the very same
+config object is returned — the no-mapper path, which is every production host
+app, is unchanged rather than merely equivalent.
+
+### Not done here
+
+Gene search and session-file loading also read through juicebox's own `igvxhr`
+and would take the same one-line treatment as the 2D path. Neither was implicated,
+so neither was touched.
+
+The honest fix is upstream: a pre-fetch URL mapper in igv.js, composed on top of
+its built-in rewrites, filed as igvteam/igv.js#2088. If that lands, the 1D half
+here collapses into registering the same mapper with igv and deleting the config
+stash and the `toJSON` un-map. The 2D half stays either way — that call site is
+ours.
 
 ## Reversal
 

--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -287,14 +287,17 @@ to avoid.
 
 ### The constraint that shapes it
 
-`HiCBrowser.toJSON` copies `config.url` verbatim. A config-time rewrite with no
+`HICBrowser.toJSON` copies `config.url` verbatim. A config-time rewrite with no
 counterpart would therefore bake `/__hic-proxy/…` into **saved sessions** —
 a session saved in development would not load in production, and would name a
 machine that is not there. Any config-time mapping owes a matching un-map on
 serialization.
 
 `mapTrackConfig` writes the mapped URLs onto a **copy** of the config and carries
-the original in `unmappedUrl` alongside; `toJSON` reads through `unmappedUrl`.
+the originals — `url` and `indexURL` both — in `unmappedUrls` alongside; `toJSON`
+reads through `unmappedUrl(config)`. Nothing serializes an index URL today; it is
+stashed anyway, because a rewrite whose original cannot be recovered is the leak
+this exists to prevent and half an invariant is worse than none.
 When no mapper is registered, or the mapper claims neither URL, the very same
 config object is returned — the no-mapper path, which is every production host
 app, is unchanged rather than merely equivalent.

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -37,6 +37,7 @@ import {getLayoutDimensions} from './layoutController.js'
 import Track2D from './track2D.js'
 
 import {DEFAULT_ANNOTATION_COLOR} from "./urlUtils.js"
+import {mapTrackConfig} from "./urlMapper.js"
 
 /**
  * DataLoader handles all data loading responsibilities for HICBrowser.
@@ -387,7 +388,10 @@ class DataLoader {
                 if (is2D) {
                     promises2D.push(Track2D.loadTrack2D(config, this.browser.genome));
                 } else {
-                    const track = await igv.createTrack(config, this.browser);
+                    // igv reads the track through its own bundled loaders, which juicebox cannot
+                    // reach into — the config's `url` is the only lever. mapTrackConfig carries the
+                    // original alongside so toJSON can serialize it. See issue #450.
+                    const track = await igv.createTrack(mapTrackConfig(config), this.browser);
 
                     if (typeof track.postInit === 'function') {
                         await track.postInit();

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -39,6 +39,7 @@ import StateManager from "./stateManager.js"
 import InteractionHandler from "./interactionHandler.js"
 import DataLoader from "./dataLoader.js"
 import RenderCoordinator from "./renderCoordinator.js"
+import {unmappedUrl} from "./urlMapper.js"
 
 const DEFAULT_PIXEL_SIZE = 1
 const MAX_PIXEL_SIZE = 128
@@ -936,9 +937,13 @@ class HICBrowser {
                 const track = trackRenderer.x.track
                 const config = track.config
 
-                if (typeof config.url === "string") {
+                // The original URL, not the one igv was given: with a dev proxy registered those
+                // differ, and a session must never carry a dev-server path. See issue #450.
+                const url = unmappedUrl(config)
 
-                    const t = {url: config.url}
+                if (typeof url === "string") {
+
+                    const t = {url}
 
                     if (config.type) {
                         t.type = config.type

--- a/js/track2D.js
+++ b/js/track2D.js
@@ -1,4 +1,5 @@
 import {igvxhr, StringUtils} from 'igv-utils'
+import {mapUrl} from './urlMapper.js'
 
 class Track2D {
 
@@ -39,7 +40,10 @@ class Track2D {
 
     static async loadTrack2D(config, genome) {
 
-        const data = await igvxhr.loadString(config.url, buildOptions(config))
+        // Mapped at the fetch, not on the config: this is a juicebox-owned call site, so the
+        // rewritten URL is used and discarded and `config.url` — the one toJSON serializes —
+        // stays the original. See issue #450.
+        const data = await igvxhr.loadString(mapUrl(config.url), buildOptions(config))
         const features = parseData(data, isBedPE(config), genome)
         return new Track2D(config, features)
     }

--- a/js/urlMapper.js
+++ b/js/urlMapper.js
@@ -1,6 +1,6 @@
 /**
- * The URL mapper — the function juicebox hands to hic-straw as `config.mapUrl` to rewrite a .hic
- * URL before it is fetched.
+ * The URL mapper — the function juicebox applies to a data URL before it is fetched: handed to
+ * hic-straw as `config.mapUrl` for a .hic read, and applied here for track reads.
  *
  * It exists so development against an origin-restricted data host does not require patching global
  * fetch. juicebox.js cannot decide for itself whether it is running in development: consumers
@@ -17,7 +17,7 @@
 let urlMapper
 
 /**
- * Register the mapper applied to every subsequent .hic read. Called once at host-app startup.
+ * Register the mapper applied to every subsequent data read. Called once at host-app startup.
  *
  * @param {(url: string) => string} [mapper] - synchronous, pure, URL in / URL out. Pass undefined
  *        to clear.
@@ -33,4 +33,68 @@ function getUrlMapper() {
     return urlMapper
 }
 
-export { setUrlMapper, getUrlMapper }
+/**
+ * Apply the registered mapper to a single URL. The place to reach for at a juicebox-owned fetch
+ * site, where the mapped value is used and immediately discarded — nothing persists it.
+ *
+ * Non-string input (a `File`, an undefined `indexURL`) is returned untouched rather than handed to
+ * the mapper, so a mapper only ever has to reason about URLs.
+ *
+ * @param {*} url
+ * @returns {*} the mapped URL, or the input unchanged when no mapper is registered.
+ */
+function mapUrl(url) {
+    const mapper = getUrlMapper()
+    return mapper && typeof url === 'string' ? mapper(url) : url
+}
+
+/**
+ * The field carrying a track config's pre-mapping URL. igv.js reads a track's URL from its config
+ * and there is no seam inside its loaders (issue #450), so the only lever juicebox has over an igv
+ * read is the `url` it hands over. That rewritten value must never escape into a saved session, so
+ * the original travels alongside it and `HiCBrowser.toJSON` serializes that instead.
+ */
+const UNMAPPED_URL = 'unmappedUrl'
+
+/**
+ * Map the URLs of a track config bound for igv, preserving the originals.
+ *
+ * Returns the config unchanged — the same object, not a copy — when no mapper is registered or when
+ * the mapper claims neither URL, which keeps the no-mapper path (every production host app)
+ * byte-for-byte what it was.
+ *
+ * @param {object} config - a 1D track config.
+ * @returns {object} the config to hand to igv.
+ */
+function mapTrackConfig(config) {
+
+    const url = mapUrl(config.url)
+    const indexURL = mapUrl(config.indexURL)
+
+    if (url === config.url && indexURL === config.indexURL) {
+        return config
+    }
+
+    const mapped = {...config, url, [UNMAPPED_URL]: config.url}
+
+    // Assigned only when there was one to begin with — an `indexURL: undefined` key that the
+    // caller never wrote is a change to the config igv sees, however inert it looks.
+    if (indexURL !== config.indexURL) {
+        mapped.indexURL = indexURL
+    }
+
+    return mapped
+}
+
+/**
+ * The URL a track config should be serialized with: the original, whenever mapTrackConfig rewrote
+ * one. Safe on any config, mapped or not.
+ *
+ * @param {object} config
+ * @returns {*} the pre-mapping URL.
+ */
+function unmappedUrl(config) {
+    return Object.hasOwn(config, UNMAPPED_URL) ? config[UNMAPPED_URL] : config.url
+}
+
+export { setUrlMapper, getUrlMapper, mapUrl, mapTrackConfig, unmappedUrl }

--- a/js/urlMapper.js
+++ b/js/urlMapper.js
@@ -49,12 +49,16 @@ function mapUrl(url) {
 }
 
 /**
- * The field carrying a track config's pre-mapping URL. igv.js reads a track's URL from its config
+ * The field carrying a track config's pre-mapping URLs. igv.js reads a track's URLs from its config
  * and there is no seam inside its loaders (issue #450), so the only lever juicebox has over an igv
- * read is the `url` it hands over. That rewritten value must never escape into a saved session, so
- * the original travels alongside it and `HiCBrowser.toJSON` serializes that instead.
+ * read is what it hands over. Those rewritten values must never escape into a saved session, so the
+ * originals travel alongside them and `HICBrowser.toJSON` serializes those instead.
+ *
+ * Every URL the mapper rewrites is stashed, `indexURL` included — nothing serializes an `indexURL`
+ * today, but a rewrite whose original cannot be recovered is exactly the leak this field exists to
+ * prevent, and half an invariant is worse than none.
  */
-const UNMAPPED_URL = 'unmappedUrl'
+const UNMAPPED_URLS = 'unmappedUrls'
 
 /**
  * Map the URLs of a track config bound for igv, preserving the originals.
@@ -75,7 +79,7 @@ function mapTrackConfig(config) {
         return config
     }
 
-    const mapped = {...config, url, [UNMAPPED_URL]: config.url}
+    const mapped = {...config, url, [UNMAPPED_URLS]: {url: config.url, indexURL: config.indexURL}}
 
     // Assigned only when there was one to begin with — an `indexURL: undefined` key that the
     // caller never wrote is a change to the config igv sees, however inert it looks.
@@ -91,10 +95,10 @@ function mapTrackConfig(config) {
  * one. Safe on any config, mapped or not.
  *
  * @param {object} config
- * @returns {*} the pre-mapping URL.
+ * @returns {*} the pre-mapping url.
  */
 function unmappedUrl(config) {
-    return Object.hasOwn(config, UNMAPPED_URL) ? config[UNMAPPED_URL] : config.url
+    return Object.hasOwn(config, UNMAPPED_URLS) ? config[UNMAPPED_URLS].url : config.url
 }
 
 export { setUrlMapper, getUrlMapper, mapUrl, mapTrackConfig, unmappedUrl }

--- a/test/testTrackUrlMapping.js
+++ b/test/testTrackUrlMapping.js
@@ -1,0 +1,233 @@
+/**
+ * A registered URL mapper must reach track reads, not only the .hic read — and must never leak the
+ * mapped URL into a saved session. See issue #450 and
+ * docs/adr/0001-dev-proxy-for-waf-protected-hosts.md.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const createTrack = vi.fn();
+
+vi.mock('igv', () => ({
+    default: { createTrack: (...args) => createTrack(...args) }
+}));
+
+vi.mock('igv-ui', () => ({
+    Alert: { presentAlert: (message) => { throw Error(message) }, init: () => undefined },
+    InputDialog: class {},
+    DOMUtils: {}
+}));
+
+const loadString = vi.fn();
+
+vi.mock('igv-utils', async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, igvxhr: { ...actual.igvxhr, loadString: (...args) => loadString(...args) } };
+});
+
+const { setUrlMapper, mapTrackConfig, unmappedUrl } = await import("../js/urlMapper.js");
+const { default: DataLoader } = await import("../js/dataLoader.js");
+const { default: Track2D } = await import("../js/track2D.js");
+const { default: HICBrowser } = await import("../js/hicBrowser.js");
+
+const PROXIED = "https://www.encodeproject.org/files/ENCFF144KUK/@@download/ENCFF144KUK.bigWig";
+
+/** The shipped mapper's shape: host-scoped, idempotent, non-http input untouched. */
+function proxyMapper(url) {
+    if (typeof url !== "string" || url.startsWith("/__hic-proxy/")) return url;
+    return url.startsWith("https://www.encodeproject.org/") ? `/__hic-proxy/${url}` : url;
+}
+
+function stubBrowser() {
+    return {
+        genome: undefined,
+        tracks2D: [],
+        showTrackLabelAndGutter: false,
+        contactMatrixView: { startSpinner: () => undefined, stopSpinner: () => undefined },
+        layoutController: { updateLayoutWithTracks: () => undefined },
+        updateLayout: async () => undefined,
+        notifyTrackLoad2D: () => undefined
+    };
+}
+
+async function configHandedToIgv(config) {
+    createTrack.mockResolvedValue({ name: "t" });
+    await new DataLoader(stubBrowser()).loadTracks([config]);
+    expect(createTrack).toHaveBeenCalledTimes(1);
+    return createTrack.mock.calls[0][0];
+}
+
+describe("mapTrackConfig", function () {
+
+    afterEach(() => setUrlMapper(undefined));
+
+    test("returns the very same config when no mapper is registered", function () {
+        const config = { url: PROXIED };
+
+        expect(mapTrackConfig(config)).toBe(config);
+    });
+
+    test("returns the very same config when the mapper claims neither URL", function () {
+        setUrlMapper(proxyMapper);
+        const config = { url: "https://example.org/a.bigWig" };
+
+        expect(mapTrackConfig(config)).toBe(config);
+    });
+
+    test("maps url and indexURL, and does not mutate the caller's config", function () {
+        setUrlMapper(proxyMapper);
+        const config = { url: PROXIED, indexURL: `${PROXIED}.tbi`, name: "ENCFF144KUK" };
+
+        const mapped = mapTrackConfig(config);
+
+        expect(mapped.url).toBe(`/__hic-proxy/${PROXIED}`);
+        expect(mapped.indexURL).toBe(`/__hic-proxy/${PROXIED}.tbi`);
+        expect(mapped.name).toBe("ENCFF144KUK");
+        expect(config.url).toBe(PROXIED);
+        expect(config.indexURL).toBe(`${PROXIED}.tbi`);
+    });
+
+    test("does not invent an indexURL key on a config that had none", function () {
+        setUrlMapper(proxyMapper);
+
+        expect(Object.hasOwn(mapTrackConfig({ url: PROXIED }), "indexURL")).toBe(false);
+    });
+
+    test("leaves a File url to the loader untouched", function () {
+        setUrlMapper(proxyMapper);
+        const config = { url: new File([], "local.bigWig") };
+
+        expect(mapTrackConfig(config)).toBe(config);
+    });
+
+    test("recovers the original url, mapped or not", function () {
+        setUrlMapper(proxyMapper);
+
+        expect(unmappedUrl(mapTrackConfig({ url: PROXIED }))).toBe(PROXIED);
+        expect(unmappedUrl({ url: "https://example.org/a.bigWig" })).toBe("https://example.org/a.bigWig");
+    });
+
+});
+
+describe("1D track loading", function () {
+
+    beforeEach(() => {
+        createTrack.mockReset();
+        // loadTracks reaches for layout dimensions and the track gutter; neither is under test.
+        global.document.querySelector = () => ({ style: {} });
+        global.getComputedStyle = () => ({ getPropertyValue: () => "0" });
+    });
+
+    afterEach(() => setUrlMapper(undefined));
+
+    test("hands igv the untouched url when no mapper is registered", async function () {
+        expect((await configHandedToIgv({ url: PROXIED, format: "bigwig" })).url).toBe(PROXIED);
+    });
+
+    test("hands igv the mapped url once a mapper is registered", async function () {
+        setUrlMapper(proxyMapper);
+
+        expect((await configHandedToIgv({ url: PROXIED, format: "bigwig" })).url)
+            .toBe(`/__hic-proxy/${PROXIED}`);
+    });
+
+    test("leaves an unclaimed host fetching directly", async function () {
+        setUrlMapper(proxyMapper);
+        const url = "https://example.org/a.bigWig";
+
+        expect((await configHandedToIgv({ url, format: "bigwig" })).url).toBe(url);
+    });
+
+    test("keeps the original url recoverable from the config igv holds", async function () {
+        setUrlMapper(proxyMapper);
+
+        expect(unmappedUrl(await configHandedToIgv({ url: PROXIED, format: "bigwig" }))).toBe(PROXIED);
+    });
+
+});
+
+/**
+ * toJSON is exercised against a minimal stand-in for a browser rather than a live one: the only
+ * part under test is which URL a track contributes to the session.
+ */
+function sessionTracksFor(trackConfigs, tracks2D = []) {
+    const stub = {
+        dataset: { url: "https://example.org/x.hic", hicFile: { config: {} } },
+        state: { toJSON: () => ({}) },
+        contactMatrixView: {
+            stringifyBackgroundColor: () => "255,255,255",
+            getColorScale: () => ({ stringify: () => "" })
+        },
+        controlDataset: undefined,
+        trackPairs: trackConfigs.map(config => ({ x: { track: { config, name: config.name } } })),
+        tracks2D
+    };
+
+    return HICBrowser.prototype.toJSON.call(stub).tracks;
+}
+
+describe("session serialization", function () {
+
+    afterEach(() => setUrlMapper(undefined));
+
+    test("emits the original url for a mapped 1D track, never a proxy path", function () {
+        setUrlMapper(proxyMapper);
+
+        const tracks = sessionTracksFor([mapTrackConfig({ url: PROXIED, name: "ENCFF144KUK" })]);
+
+        expect(tracks).toHaveLength(1);
+        expect(tracks[0].url).toBe(PROXIED);
+    });
+
+    test("emits an unmapped 1D track's url unchanged", function () {
+        const url = "https://example.org/a.bigWig";
+
+        expect(sessionTracksFor([{ url, name: "a" }])[0].url).toBe(url);
+    });
+
+    test("keeps a mapped 2D track's url original", function () {
+        setUrlMapper(proxyMapper);
+        const url = "https://www.encodeproject.org/x.bedpe";
+        const track2D = new Track2D({ url }, []);
+
+        expect(sessionTracksFor([], [track2D])[0].url).toBe(url);
+    });
+
+});
+
+describe("2D track loading", function () {
+
+    beforeEach(() => {
+        loadString.mockReset();
+        loadString.mockResolvedValue("chr1\t100\t200\tchr1\t300\t400");
+    });
+
+    afterEach(() => setUrlMapper(undefined));
+
+    test("fetches the untouched url when no mapper is registered", async function () {
+        const url = "https://www.encodeproject.org/x.bedpe";
+
+        await Track2D.loadTrack2D({ url });
+
+        expect(loadString.mock.calls[0][0]).toBe(url);
+    });
+
+    test("fetches the mapped url once a mapper is registered", async function () {
+        setUrlMapper(proxyMapper);
+        const url = "https://www.encodeproject.org/x.bedpe";
+
+        await Track2D.loadTrack2D({ url });
+
+        expect(loadString.mock.calls[0][0]).toBe(`/__hic-proxy/${url}`);
+    });
+
+    test("serializes the original url — the config is never rewritten", async function () {
+        setUrlMapper(proxyMapper);
+        const url = "https://www.encodeproject.org/x.bedpe";
+
+        const track2D = await Track2D.loadTrack2D({ url });
+
+        expect(track2D.config.url).toBe(url);
+        expect(track2D.toJSON().url).toBe(url);
+    });
+
+});

--- a/test/testTrackUrlMapping.js
+++ b/test/testTrackUrlMapping.js
@@ -84,6 +84,10 @@ describe("mapTrackConfig", function () {
         expect(mapped.name).toBe("ENCFF144KUK");
         expect(config.url).toBe(PROXIED);
         expect(config.indexURL).toBe(`${PROXIED}.tbi`);
+
+        // Both originals are recoverable, index included: a rewrite whose original is lost is the
+        // leak the stash exists to prevent, whether or not anything serializes it today.
+        expect(mapped.unmappedUrls).toEqual({ url: PROXIED, indexURL: `${PROXIED}.tbi` });
     });
 
     test("does not invent an indexURL key on a config that had none", function () {
@@ -182,6 +186,20 @@ describe("session serialization", function () {
         const url = "https://example.org/a.bigWig";
 
         expect(sessionTracksFor([{ url, name: "a" }])[0].url).toBe(url);
+    });
+
+    test("round-trips: a session saved with a mapper reloads with none registered", async function () {
+        setUrlMapper(proxyMapper);
+        global.document.querySelector = () => ({ style: {} });
+        global.getComputedStyle = () => ({ getPropertyValue: () => "0" });
+        createTrack.mockReset();
+
+        const saved = sessionTracksFor([await configHandedToIgv({ url: PROXIED, format: "bigwig" })]);
+        setUrlMapper(undefined);
+        createTrack.mockReset();
+
+        // Reloading the saved session in production — no mapper — must fetch the real host.
+        expect((await configHandedToIgv(saved[0])).url).toBe(PROXIED);
     });
 
     test("keeps a mapped 2D track's url original", function () {


### PR DESCRIPTION
Closes #450.

`setUrlMapper` reached exactly one consumer — hic-straw's `config.mapUrl` — so a dev-proxied host served its `.hic` map while every track on the same host failed. The proxy middleware was never the problem; it is host-generic and already serves a bigWig correctly. Nothing routed track reads into it.

## Two transports, two treatments

**2D annotations** are read by juicebox itself, at `Track2D.loadTrack2D`. Our call site, so the mapper applies **at the fetch**: the mapped URL is used and discarded, `config.url` stays original, and `Track2D.toJSON` needed no change at all.

**1D tracks** go to `igv.createTrack` and are read by igv's own bundled `igvxhr`, whose URL rewriting is module-private (`igv.esm.js` ships three copies, so patching the `igv-utils` dependency does not reach them). `igv.setCORSProxy` cannot substitute — its retry is gated on `xhr.status === 0`/`onerror`, and ENCODE's `405` carries valid CORS headers, so `onload` runs and goes straight to the error path. That leaves one lever: the `url` in the config igv is handed.

## The constraint that shapes it

`HICBrowser.toJSON` copies `config.url` verbatim, so a config-time rewrite with no counterpart would bake `/__hic-proxy/…` into **saved sessions** — a session saved in development would name a machine that isn't there. `mapTrackConfig` writes the mapped URLs onto a *copy* of the config and carries the originals (`url` and `indexURL` both) in `unmappedUrls`; `toJSON` reads through `unmappedUrl(config)`.

With no mapper registered — every production host app — `mapTrackConfig` returns the caller's **same object**, so that path is unchanged rather than merely equivalent.

## Verification

297 unit tests pass, 17 of them new; each behavioural test was confirmed red without its fix.

The acceptance criterion that cannot be a unit test was run for real, headless against live ENCODE from localhost — probe 4, added to `dev/encode-dev-proxy.html`. An ENCODE bigWig (1D, igv's loaders) and an ENCODE `.bedpe.gz` (2D, juicebox's) both load through the proxy, the bigWig renders above the map, and `browser.toJSON()` emits both original `encodeproject.org` URLs.

## Notes

- Nothing verifies that igv preserves an unknown key on `track.config`. The headless run proves it does for bigWig, but it is undocumented igv behaviour. The upstream fix (igvteam/igv.js#2088) would delete the 1D half of this mechanism entirely; the 2D half stays either way.
- Gene search and session-file reads still bypass the mapper. Same one-line treatment as the 2D path would apply; neither was implicated and the brief put them out of scope. Recorded in the ADR.
- Docs amended as the acceptance criteria required: `README.md`, `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md` (dated amendment retracting the "`.hic` reads only" scope line), and the `CONTEXT.md` glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)