### PR TITLE
Restore the UCSC refGene URL in the published example

### DIFF
--- a/examples/juicebox.html
+++ b/examples/juicebox.html
@@ -44,7 +44,7 @@
                     "name": "Homo sapiens GM12878 CTCF "
                 },
                 {
-                    "url": "https://s3.amazonaws.com/igv.org.genomes/hg19/refGene.sorted.txt.gz",
+                    "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz",
                     "type": "annotation",
                     "format": "refgene",
                     "name": "Refseq Genes",


### PR DESCRIPTION
Closes #457. Follow-up to #456, reverting the URL swap it made.

PR #456 pointed the Refseq Genes track in `examples/juicebox.html` at an
igv.org.genomes copy to work around a TLS handshake that hung from one
network location. @jrobinso noted UCSC is the correct source for this
track, and README.md already documents the UCSC URL — so the example and
the README now agree.

URL-only change; `type`, `format`, and `name` are untouched.

## Verification

- The example's track config is now character-identical to the block in README.md
- `https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz` returns `HTTP/1.1 200`
- Full test suite: 297 passed / 17 files

Not verified: that the track renders in a browser. The 200 above was from
this machine — if the TLS hang that motivated #456 still occurs from your
network, the example will stall on this track even though the config is
correct.

Note: the `dev/` refGene tracks are left on igv.org.genomes (863da53), as #457 scopes to the published example only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)