### PR TITLE
Restore the UCSC refGene URLs in the dev fixtures

### DIFF
--- a/dev/dat-sequence-gene-track.html
+++ b/dev/dat-sequence-gene-track.html
@@ -50,8 +50,7 @@
                     {
                         name: "Refseq Genes - As Track",
                         format: "refgene",
-                        url: "https://s3.amazonaws.com/igv.org.genomes/hg38/ncbiRefSeq.txt.gz",
-                        indexURL: "https://s3.amazonaws.com/igv.org.genomes/hg38/ncbiRefSeq.txt.gz.tbi"
+                        url: "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeq.txt.gz"
                     },
                     {
                         name: "Sequence - As Track",
@@ -80,8 +79,7 @@
                     {
                         name: "Refseq Genes - As Track",
                         format: "refgene",
-                        url: "https://s3.amazonaws.com/igv.org.genomes/hg38/ncbiRefSeq.txt.gz",
-                        indexURL: "https://s3.amazonaws.com/igv.org.genomes/hg38/ncbiRefSeq.txt.gz.tbi"
+                        url: "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/ncbiRefSeq.txt.gz"
                     },
                     {
                         name: "Sequence - As Track",

--- a/dev/generic-test-harness.html
+++ b/dev/generic-test-harness.html
@@ -55,10 +55,18 @@
     // an ENCODE map in a config below loads while its hicfiles tracks do not.
     //
     // Also verified reachable today: the wasabisys buckets, dropbox, and the
-    // igv.org.genomes / igv.broadinstitute.org buckets. hgdownload.soe.ucsc.edu
-    // is NOT reachable over HTTPS -- it accepts the TCP connection but never
-    // completes the TLS handshake, so a track pointed at it hangs until igv
-    // times out. Use the igv.org.genomes copies instead.
+    // igv.org.genomes / igv.broadinstitute.org buckets.
+    //
+    // hgdownload.soe.ucsc.edu once appeared unreachable over HTTPS -- it
+    // accepted the TCP connection but never completed the TLS handshake, so a
+    // track pointed at it hung until igv timed out. That was observed from one
+    // network location, not a property of the host: it returned 200 over HTTPS
+    // when re-probed on 2026-08-05. If it hangs for you, suspect your network
+    // path before changing these URLs -- UCSC is the canonical source for the
+    // refGene tracks and the URLs here should stay pointed at it.
+    //
+    // UCSC serves no tabix index for ncbiRefSeq.txt.gz -- the .tbi is 404 at
+    // both the hg19 and hg38 paths -- so these tracks must not set an indexURL.
     // ------------------------------------------------------------------
 
     // Map and 2D track both verified reachable. The pairing is the one used by
@@ -262,7 +270,7 @@
             "colorScale": "66.20668236071833,255,0,0",
             "tracks": [
                 {
-                    "url": "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.txt.gz",
+                    "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz",
                     "type": "annotation",
                     "format": "refgene",
                     "name": "Refseq Genes",

--- a/dev/jquery-cleanse.html
+++ b/dev/jquery-cleanse.html
@@ -50,7 +50,7 @@
             "colorScale": "66.20668236071833,255,0,0",
             "tracks": [
                 {
-                    "url": "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.txt.gz",
+                    "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz",
                     "type": "annotation",
                     "format": "refgene",
                     "name": "Refseq Genes",


### PR DESCRIPTION
Closes #458. Follow-up to #456, reverting the workaround commit `863da53` applied to the dev fixtures — the same revert #459 made for the published example.

## Changes

Four track configs repointed at UCSC:

- `dev/generic-test-harness.html` — hg19
- `dev/jquery-cleanse.html` — hg19
- `dev/dat-sequence-gene-track.html` — hg38, both configs

The `indexURL` lines in `dat-sequence-gene-track.html` are **removed rather than repointed**: UCSC serves no tabix index for `ncbiRefSeq.txt.gz`. Leaving them pointed anywhere would fail the track on a missing index.

The reachability note in `generic-test-harness.html` asserted flatly that `hgdownload.soe.ucsc.edu` is not reachable over HTTPS and that the igv.org.genomes copies should be used. That reads as a standing property of the host and isn't one — it's reworded as a single-location observation so the next reader doesn't swap these URLs back.

## Verification

Probed 2026-08-05, both premises behind this change confirmed independently:

| URL | Status |
|---|---|
| `hg19/database/ncbiRefSeq.txt.gz` | 200 |
| `hg38/database/ncbiRefSeq.txt.gz` | 200 |
| `hg19/database/ncbiRefSeq.txt.gz.tbi` | 404 |
| `hg38/database/ncbiRefSeq.txt.gz.tbi` | 404 |

- No field other than `url` / `indexURL` changed in any config
- All four edited pages parse (`node --check` over their inline scripts)
- Full test suite: 297 passed / 17 files

**Not verified: the three dev pages rendering their gene tracks in a browser** (acceptance criterion 5). This is static verification plus HTTP probes only. Worth a look before merge, since dropping `indexURL` means these tracks now stream the whole file rather than range-reading an index.

Scope note: the comment block gained a line recording that UCSC serves no tabix index, which #458 didn't ask for. It's there so the removed `indexURL` doesn't get helpfully restored later — say the word and I'll drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)