### PR TITLE
Scope the ADR's CORS finding to the data hosts

### DIFF
--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -37,6 +37,15 @@ Ruled out during diagnosis, do not re-investigate: bucket permissions differing 
 requester; CORS on the data hosts (all return `Access-Control-Allow-Origin: *`);
 preflight failure; a juicebox.js regression.
 
+That CORS finding covers the hosts serving `.hic` bytes, and only those. It does
+not generalise to every host a consumer fetches from: `aidenlab.org`, which
+served juicebox-web's contact-map menu, returned no `Access-Control-Allow-Origin`
+at all — measured 2026-08-05, zone-wide, for every origin and every path, so the
+menu was empty anywhere but production. That was juicebox.js#444, transferred to
+juicebox-web#56 because nothing in this repo referenced the file, and fixed there
+by serving the menu from the app rather than fetching it cross-origin. Check the
+host in front of you rather than assuming this line covers it.
+
 ## Decision
 
 Ship a **dev-only** proxy in this repo, built on the hic-straw extension points,


### PR DESCRIPTION
Documentation only, no code change.

`docs/adr/0001` lists under do-not-re-investigate:

> CORS on the data hosts (all return `Access-Control-Allow-Origin: *`)

True of the hosts serving `.hic` bytes, and it stays. But it reads as covering every host a consumer fetches from, which it does not — and that cost real time this week.

`aidenlab.org`, which served juicebox-web's contact-map menu, returns no `Access-Control-Allow-Origin` at all: measured zone-wide, for every origin and every path. The menu was empty anywhere but production.

That was #444 in this repo — filed here because the diagnosis happened here, though nothing in this repo ever referenced the file. It has been transferred to aidenlab/juicebox-web#56 and fixed there by serving the menu from the app instead of fetching it cross-origin (juicebox-web #57 and #58, both merged).

This adds a paragraph scoping the claim and pointing at where it went. A ruled-out list that quietly over-generalises is worse than no list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)