### PR TITLE
Point the README and examples at browser-reachable demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements:
 
 * Juicebox CSS
 
-    ``` <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/juicebox.js@2.4.8/dist/css/juicebox.css">```
+    ``` <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/juicebox.js@3.6.2/dist/css/juicebox.css">```
     
 * Juicebox javascript -- see below
 
@@ -21,13 +21,13 @@ Requirements:
 To import juicebox as an ES6 module
 
 ```javascript
-import juicebox from "https://cdn.jsdelivr.net/npm/juicebox.js@2.4.8/dist/juicebox.esm.js";
+import juicebox from "https://cdn.jsdelivr.net/npm/juicebox.js@3.6.2/dist/juicebox.esm.js";
 ``` 
 
 Or as a script include (defines the "juicebox" global)
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/juicebox.js@2.4.8/dist/juicebox.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/juicebox.js@3.6.2/dist/juicebox.min.js"></script>
 ```   
  
 Alternatively you can install with npm  
@@ -55,7 +55,7 @@ Configuration ```config``` object examples follow
 
 ```
    const config = {
-       "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic",    
+       "url": "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic",    
    }
 
 ```
@@ -70,8 +70,8 @@ Configuration ```config``` object examples follow
 
 ```
    const config = {
-            "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic",
-            "name": "Combined",
+            "url": "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic",
+            "name": "GM12878 in situ combined",
             "locus": "18:28,504,357-29,748,974 18:28,504,357-29,748,974",
             "normalization": "VC_SQRT",
             "backgroundColor": "255,255,255",
@@ -81,7 +81,7 @@ Configuration ```config``` object examples follow
                     "url": "https://www.encodeproject.org/files/ENCFF144KUK/@@download/ENCFF144KUK.bigWig",
                     "type": "wig",
                     "format": "bigwig",
-                    "name": "Homo sapiens GM12878 CTCF "
+                    "name": "Homo sapiens GM12878 CTCF",
                     "color": "green"
                 },
                 {
@@ -91,18 +91,14 @@ Configuration ```config``` object examples follow
                     "name": "Refseq Genes",
                 },
                 {
-                    "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/combined_peaks.txt",
-                    "name": "Rao & Huntley et al. | Cell 2014 | GM12878 combined loops"
-                },
-                {
-                    "url": "https://hicfiles.s3.amazonaws.com/hiseq/hap1/in-situ/combined_peaks.txt",
-                    "name": "Sanborn & Rao et al. | PNAS 2015 | Hap1 loops",
+                    "url": "https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/data/test/bedpe/GM12878_loops.bedpe",
+                    "name": "Rao & Huntley et al. | Cell 2014 | GM12878 loops",
                     "color": "#fffa03",
                     "displayMode": "upper"
                 },
                 {
-                    "url": "https://hicfiles.s3.amazonaws.com/external/mumbach/GSE80820_HiChIP_GM_cohesin_peaks.txt",
-                    "name": "Mumbach Rubin Flynn et al. | Nature Methods 2016 | GM12878 cohesin combined loops",
+                    "url": "https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/data/test/bedpe/GSM1872886_GM12878_CTCF_PET.bedpe.txt",
+                    "name": "Tang et al. | Cell 2015 | GM12878 CTCF ChIA-PET",
                     "color": "#000000",
                     "displayMode": "lower"
                 }

--- a/examples/juicebox-minimal.html
+++ b/examples/juicebox-minimal.html
@@ -30,7 +30,7 @@ juicebox.setUrlMapper(devMapUrl)
 
 const config =
         {
-            "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic",
+            "url": "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic",
         }
 
         const browser = await juicebox.init(document.getElementById("app-container"), config)

--- a/examples/juicebox.html
+++ b/examples/juicebox.html
@@ -31,8 +31,8 @@
     const config =
         {
             "backgroundColor": "255,255,255",
-            "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/dilution/combined.hic",
-            "name": "Combined",
+            "url": "https://www.encodeproject.org/files/ENCFF718AWL/@@download/ENCFF718AWL.hic",
+            "name": "GM12878 in situ combined",
             "locus": "18:28,504,357-29,748,974 18:28,504,357-29,748,974",
             "normalization": "VC_SQRT",
             "colorScale": "66.20668236071833,255,0,0",
@@ -41,7 +41,8 @@
                     "url": "https://www.encodeproject.org/files/ENCFF144KUK/@@download/ENCFF144KUK.bigWig",
                     "type": "wig",
                     "format": "bigwig",
-                    "name": "Homo sapiens GM12878 CTCF "
+                    "name": "Homo sapiens GM12878 CTCF",
+                    "color": "green"
                 },
                 {
                     "url": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/ncbiRefSeq.txt.gz",
@@ -50,18 +51,14 @@
                     "name": "Refseq Genes",
                 },
                 {
-                    "url": "https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/combined_peaks.txt",
-                    "name": "Rao & Huntley et al. | Cell 2014 | GM12878 combined loops"
-                },
-                {
-                    "url": "https://hicfiles.s3.amazonaws.com/hiseq/hap1/in-situ/combined_peaks.txt",
-                    "name": "Sanborn & Rao et al. | PNAS 2015 | Hap1 loops",
+                    "url": "https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/data/test/bedpe/GM12878_loops.bedpe",
+                    "name": "Rao & Huntley et al. | Cell 2014 | GM12878 loops",
                     "color": "#fffa03",
                     "displayMode": "upper"
                 },
                 {
-                    "url": "https://hicfiles.s3.amazonaws.com/external/mumbach/GSE80820_HiChIP_GM_cohesin_peaks.txt",
-                    "name": "Mumbach Rubin Flynn et al. | Nature Methods 2016 | GM12878 cohesin combined loops",
+                    "url": "https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/data/test/bedpe/GSM1872886_GM12878_CTCF_PET.bedpe.txt",
+                    "name": "Tang et al. | Cell 2015 | GM12878 CTCF ChIA-PET",
                     "color": "#000000",
                     "displayMode": "lower"
                 }


### PR DESCRIPTION
Closes #429.

The README's two config examples named `hicfiles.s3.amazonaws.com`, which serves 403 to a browser. Anyone copying the quick-start into their own app got a message-less error and no map. The dev proxy does not help: it is `apply: 'serve'` and never reaches a consumer's build.

## Swaps

Matched on genome (hg19) so the chr18 locus and the 2D tracks still line up:

| | was | now |
|---|---|---|
| map | `hiseq/gm12878/dilution/combined.hic` | ENCODE `ENCFF718AWL` — GM12878 in situ combined |
| loops | `gm12878/in-situ/combined_peaks.txt` | igv-data `GM12878_loops.bedpe` |
| 2D | `hap1/…` + Mumbach HiChIP | igv-data `GSM1872886_GM12878_CTCF_PET.bedpe.txt` |

The Hap1 and Mumbach tracks have no reachable equivalent and are dropped; two tracks still demonstrate `displayMode` upper/lower. The ENCODE bigWig and UCSC refGene track were already reachable and are unchanged.

`ENCFF718AWL` is the accession `examples/juicebox-api.html` already labels GM12878.

## Why not GM12878_domains.bedpe

It was the obvious second 2D track and it is wrong. `js/track2D.js:104` reads per-feature color from column index 10 for any `.bedpe`; that file carries color at index 6 with a float at 10, so every feature would render as `rgb(0.4308)` — silently, since the track still draws. `hiccups_loops.bedpe` fails the same way with a quoted value. The CTCF PET file has 7 columns, never enters that branch, and the config's `color` applies.

## Also

- Fixed a missing comma that made the README's second snippet invalid JS.
- Repointed the CDN pins from `2.4.8` to `3.6.2`.
- `examples/juicebox.html` and `juicebox-minimal.html` now match the README blocks they are cross-referenced from. Neither depends on the dev proxy any more.

## Verification

All five README data URLs return 206 to a browser User-Agent from a foreign Origin. `examples/juicebox.html` rendered under `npm run dev`: map opens at the chr18 locus, both 2D tracks draw in the correct triangles with the configured colors. 297 tests pass.

## Follow-up, not in this PR

`www.encodeproject.org` now returns 307 → signed S3 → 206 to a plain browser UA from any Origin, with `access-control-allow-origin: *`. The 405 WAF gate is gone. README lines 158–163, `docs/adr/0001`, and the `CHALLENGED_HOSTS` entry in `dev-proxy/map-url.js:64` all still describe the old behaviour and want a re-measure. The two S3 buckets are unchanged and still need the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)