### PR TITLE
Remove stale color-scale entries from the UI component map

### DIFF
--- a/js/browserUIManager.js
+++ b/js/browserUIManager.js
@@ -85,9 +85,6 @@ class BrowserUIManager {
 
         this.components.set('sweepZoom', sweepZoom);
         this.components.set('scrollbar', scrollbarWidget);
-        this.components.set('colorScale', colorScale);
-        this.components.set('ratioColorScale', ratioColorScale);
-        this.components.set('diffColorScale', diffColorScale);
 
         const browser = this.browser;
 


### PR DESCRIPTION
Closes #437.

## What changed

Dropped the three `this.components.set(...)` calls for `colorScale`, `ratioColorScale` and `diffColorScale` from `BrowserUIManager`. The local `const`s stay — they are still passed into the `ImageTileSource` constructor immediately below, which is the real handoff.

## Why

Two problems, both from #437 and both re-verified against the code:

1. **Nothing read them.** Every `getComponent` call site in the repo — in `js/hicBrowser.js`, `js/browserCoordinator.js` and `js/browserUIManager.js` itself — asks for `contactMatrix`, `controlMap`, `chromosomeSelector`, `resolutionSelector`, `normalization`, `colorScaleWidget`, `locusGoto` or `scrollbar`. None of the three scale keys was ever fetched, including from tests.
2. **They went stale.** `ImageTileSource` replaces the primary scale on an automatic threshold change, and `setColorScale` replaces any of the three. The component map kept pointing at the originals, so a future reader trusting `getComponent('colorScale')` would get a detached object with a stale threshold.

`ImageTileSource` is the storage of record and `ContactMatrixView.colorScale` is a read-through getter. These entries were a leftover from before that ownership moved.

`BrowserUIManager` has no class-level doc comment or component inventory to update — the only header in the file is the MIT license.

## Verification

- `npm run test:run` — 297 passed across 17 files.
- **Browser smoke test not yet run.** #437 asks for a map load confirming the contact matrix still renders and the color-scale widget still tracks. The grep says no live reader exists, but per the issue: if this does break something, that is a reader the grep missed and worth calling out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)