### PR TITLE
Correct the stale ENCODE CAPTCHA claim in three places (#463)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ Note: The Vite dev server is required because the source files use bare npm impo
 
 ## Loading maps from hosts that refuse a browser
 
-Some data hosts refuse the request a browser is able to make, so their maps cannot be loaded in development without help. Two gates are known:
+Some data hosts refuse the request a browser is able to make, so their maps cannot be loaded in development without help. One gate is live today:
 
-- **A bot challenge keyed on `Origin`** — `www.encodeproject.org` puts AWS WAF in front of its files and answers any origin not on its allowlist with a CAPTCHA page, under a misleading `405`. `localhost` is never allowlisted.
 - **A `User-Agent` allowlist** — `hicfiles.s3.amazonaws.com` and `dnazoo.s3.amazonaws.com` serve `403` unless the request carries an allowlisted `User-Agent`. No browser can comply: `User-Agent` is a forbidden header name in the Fetch spec, so the value the client libraries set is dropped before the request leaves.
+
+`www.encodeproject.org` is also routed through the proxy, but as a precaution rather than a live need: as of 2026-08-05 it serves `@@download` reads to any origin, so ENCODE maps and tracks load in development either way. It stays in the table because AWS WAF rules there have been switched on before and the entry costs one line.
 
 `dev-proxy/` is a **development-only** workaround: a Vite plugin that refetches the file from Node, where those headers are ours to set, plus the client-side rule that decides which hosts get routed that way. It is already wired into this repo's dev server — see `dev/encode-dev-proxy.html`. In a host application:
 

--- a/dev-proxy/map-url.js
+++ b/dev-proxy/map-url.js
@@ -38,19 +38,20 @@ const IGV_PREFIXED_USER_AGENT = 'IGV-juicebox.js-dev-proxy (+https://github.com/
  * Hosts that refuse the request a browser is able to make, and what the proxy must do differently
  * for each. Adding a host here and nothing else is the whole fix for the next one.
  *
- * Two gates are known, and they want opposite things — which is why the header set is a property
- * of the host rather than one constant for every target:
+ * The header set is a property of the host rather than one constant for every target, because the
+ * hosts here do not want the same thing:
  *
- *   ENCODE           AWS WAF challenging browser traffic from a domain ENCODE has not approved.
- *                    Nothing to override: a request that does not claim to be a browser skips that
- *                    check and is served whatever domain it names. The shared header set already
- *                    identifies the proxy honestly, which is the whole of what this host needs.
+ *   ENCODE           Routed as a precaution, not for a live gate. Measured 2026-08-05: ENCODE
+ *                    serves `@@download` reads 307 → signed S3 for every origin tried — aidenlab,
+ *                    localhost, a stranger's domain, none — and for browser and non-browser
+ *                    User-Agents alike. No CAPTCHA, no `X-Amzn-Waf-Action`. An earlier AWS WAF
+ *                    rule did challenge unapproved origins; it is gone, and the entry stays only
+ *                    because it has been switched on before and costs one line.
  *
- *                    Measured 2026-08-04: with the honest User-Agent below, ENCODE returns 307 for
- *                    `Origin: https://aidenlab.org`, for a stranger's domain, for localhost and for
- *                    no Origin at all. So `claimsOrigin` is not set here — it bought nothing, and
- *                    not setting it means a developer outside aidenlab is not made to claim
- *                    aidenlab's identity from their own machine.
+ *                    Nothing to override, so the rule is empty. `claimsOrigin` is not set: it
+ *                    bought nothing even when the gate was live, and not setting it means a
+ *                    developer outside aidenlab is not made to claim aidenlab's identity from
+ *                    their own machine.
  *
  *   `claimsOrigin`   assert the plugin's `origin` option. No host needs it today; it remains for
  *                    DEFAULT_RULE and for a gate that reads `Origin` whatever the caller claims.
@@ -59,10 +60,10 @@ const IGV_PREFIXED_USER_AGENT = 'IGV-juicebox.js-dev-proxy (+https://github.com/
  *                    Fetch spec, so no browser can satisfy it however the client library asks;
  *                    Node can. These hosts are not Origin-sensitive, so none is claimed for them.
  *
- * Note the asymmetry with the two gates' response shapes, which matters to the middleware: the
- * Origin-challenged host answers with a redirect to signed storage, so its payload never crosses
- * Node. These buckets serve the object directly, so for them the dev server really is the data
- * path. Ranged reads are relayed as they arrive. See docs/adr/0001.
+ * Note the asymmetry in the hosts' response shapes, which matters to the middleware: ENCODE answers
+ * with a redirect to signed storage, so its payload never crosses Node. These buckets serve the
+ * object directly, so for them the dev server really is the data path. Ranged reads are relayed as
+ * they arrive. See docs/adr/0001.
  */
 const CHALLENGED_HOSTS = {
     'www.encodeproject.org': {},

--- a/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
+++ b/docs/adr/0001-dev-proxy-for-waf-protected-hosts.md
@@ -1,7 +1,7 @@
 # ADR-0001 — Dev-time proxy for data hosts that refuse a browser
 
 **Status:** Accepted
-**Last measured:** 2026-08-04
+**Last measured:** 2026-08-05
 **Depends on:** hic-straw `docs/adr/0001-transport-extension-points.md`
 
 This describes the current state. Earlier revisions carried a running history of
@@ -10,28 +10,37 @@ Anything not here is in the git history.
 
 ## Context
 
-Two data hosts refuse the request a browser makes, for different reasons.
-
-**`www.encodeproject.org`** is behind AWS WAF. A request whose `User-Agent` looks
-like a browser is checked against the domains ENCODE has approved — `aidenlab.org`
-and `igv.org` are approved — and anything else gets a CAPTCHA page under a
-misleading `405`, with `X-Amzn-Waf-Action: captcha` in the response headers. A
-background `fetch` cannot solve a CAPTCHA, so the load fails.
-
-**A request that does not claim to be a browser skips that check entirely** and is
-served whatever domain it names. Measured 2026-08-04 with the proxy's own honest
-`User-Agent`: `307` for `aidenlab.org`, for an unrelated domain, for `localhost`,
-and for no `Origin` at all. That exemption is the whole mechanism of the proxy.
-
-**`hicfiles.s3.amazonaws.com` and `dnazoo.s3.amazonaws.com`** serve `403` unless
+**`hicfiles.s3.amazonaws.com` and `dnazoo.s3.amazonaws.com`** refuse the request a
+browser makes. They serve `403` unless
 the `User-Agent` starts with `IGV` — a case-sensitive prefix match, measured
 2026-08-03. `IGV`, `IGVX`, `IGV/2.19.1` and `IGV-dev-proxy` all pass; `igv`,
 `Juicebox`, every browser value and an empty `User-Agent` are refused.
 
-**A browser cannot satisfy either gate**, because it cannot set `User-Agent`.
+**A browser cannot satisfy that gate**, because it cannot set `User-Agent`.
 Measured 2026-08-04: `fetch` and `XMLHttpRequest` both send the browser's own value
-whatever the caller asks for. So there is no client-side fix. The only options are
-an approved domain, or a request made from something that is not a browser.
+whatever the caller asks for. So there is no client-side fix — only a request made
+from something that is not a browser.
+
+**`www.encodeproject.org`** was the second gate, and is no longer one. It sits
+behind AWS WAF, and a rule there once challenged browser-looking requests from
+domains ENCODE had not approved, answering with a CAPTCHA page under a misleading
+`405` and `X-Amzn-Waf-Action: captcha`. That rule is gone. Measured 2026-08-05 on
+`@@download` reads of both `.bigWig` and `.hic` files: `307` to signed S3 —
+followed, `206` — for `Origin: https://aidenlab.org`, for `http://localhost:3000`,
+for a stranger's domain and for no `Origin`, under browser and non-browser
+`User-Agent` alike. No CAPTCHA header, no `405`, from any combination.
+
+ENCODE stays in `CHALLENGED_HOSTS` regardless. The entry is one line, the extra hop
+is dev-only, and a WAF rule that was switched on once can be switched on again;
+routing it costs nothing and means the next time it happens nothing breaks. The
+CAPTCHA branch in `presentError` stays for the same reason.
+
+One measurement is unresolved and not worth resolving: a spoofed Chrome
+`User-Agent` draws `502` from awselb from *every* origin, including an approved
+one, while spoofed Firefox and Safari values are served. Read as the WAF catching a
+UA that contradicts its TLS fingerprint — curl claiming to be Chrome. Confirming
+that would need a real browser at a real non-`localhost` origin. It does not change
+anything here: development against ENCODE works, proxied or direct.
 
 Ruled out during diagnosis, do not re-investigate: bucket permissions differing by
 requester; CORS on the data hosts (all return `Access-Control-Allow-Origin: *`);
@@ -84,17 +93,17 @@ claiming it would route strangers' data through the dev server.
 
 ### What the proxy sends
 
-An honest `User-Agent` naming itself, which is what puts it in ENCODE's exempt
-branch, and `IGV-juicebox.js-dev-proxy (+…)` for the two buckets — the prefix
-satisfies the gate without claiming to *be* IGV.
+An honest `User-Agent` naming itself, and `IGV-juicebox.js-dev-proxy (+…)` for the
+two buckets — the prefix satisfies the gate without claiming to *be* IGV.
 
-**No `Origin` is claimed for any of the three.** It bought nothing, and not
-claiming one means a developer outside aidenlab is not made to assert aidenlab's
-identity from their own machine. `DEFAULT_RULE` still claims one for a host with no
-rule of its own, which is unmeasured territory either way.
+**No `Origin` is claimed for any of the three.** It bought nothing even when
+ENCODE's gate was live, and not claiming one means a developer outside aidenlab is
+not made to assert aidenlab's identity from their own machine. `DEFAULT_RULE` still
+claims one for a host with no rule of its own, which is unmeasured territory either
+way.
 
 Do not impersonate a browser: a spoofed Chrome `User-Agent` draws `502` from awselb
-even from an approved domain.
+from every origin, approved or not.
 
 ### How redirects are handled
 
@@ -136,22 +145,24 @@ third-party embedder's problem, but it stops the failure being a lie.
 - Adoption is two lines per host app, in dev configuration only.
 - Production behaviour is unchanged. **Nothing here makes a deployed app work that
   did not work before** — a third party embedding juicebox.js on their own domain
-  is still blocked, and only ENCODE can fix that.
-- Both production consumers work *only* because they are served from
-  `aidenlab.org`. If either moved domains they would start failing against ENCODE
-  the day they moved. Measured, not predicted: a real browser at an unapproved
-  domain is challenged exactly as a spoofed one is.
+  still cannot read the two buckets, and only an AWS-side change fixes that.
+- ENCODE is no longer part of that story. Since the WAF rule lapsed, a deployed app
+  on any domain reads ENCODE directly; the consumers no longer depend on being
+  served from `aidenlab.org` for it.
 - The list of proxied hosts must be maintained. The next host that starts refusing
   is a fresh mystery until someone adds it — mitigated by the legible error.
 
 ## Reversal
 
-A **workaround with an expiry condition**. If ENCODE exempts the `@@download`
-endpoints or approves the domains in question, **and** the `IGV` prefix requirement
-is lifted on the two buckets — those are this project's own buckets, so that half
-needs AWS access rather than a commit — **delete `dev-proxy/` entirely** along with
-its `exports` entries and both host apps' two lines. Either alone retires only its
-own host from `CHALLENGED_HOSTS`.
+A **workaround with an expiry condition**, and half of it has already expired:
+ENCODE's `@@download` endpoints are open again as of 2026-08-05. That alone does
+not retire anything — ENCODE stays in `CHALLENGED_HOSTS` as a precaution, see
+Context.
+
+The live condition is the `IGV` prefix requirement on the two buckets. Those are
+this project's own buckets, so lifting it needs AWS access rather than a commit.
+When it is lifted, **delete `dev-proxy/` entirely** along with its `exports`
+entries and both host apps' two lines.
 
 `setUrlMapper` and the hic-straw extension points may stay; they are generic and
 cost nothing. The legible-error change should outlive the reversal.


### PR DESCRIPTION
Closes #463.

ENCODE's AWS WAF rule that challenged browser traffic from unapproved origins is gone. Measured 2026-08-05 on `@@download` reads of `.bigWig` (`ENCFF144KUK`) and `.hic` (`ENCFF718AWL`, `ENCFF406HHC`):

| User-Agent | Origin | Result |
|---|---|---|
| `Mozilla/5.0` | aidenlab.org / localhost:3000 / example.com / none | 307 → S3 → 206 |
| Real Firefox 127 | example.com | 307 |
| Real Safari 17.4 | example.com | 307 |
| Honest proxy UA / `curl/8.7.1` | example.com / none | 307 |

No `X-Amzn-Waf-Action: captcha` and no `405` from any combination.

Three places still described that gate as live, and all three are corrected here: `README.md`, `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`, and the `CHALLENGED_HOSTS` comment in `dev-proxy/map-url.js`.

**ENCODE stays in `CHALLENGED_HOSTS`.** Now documented as a precaution rather than a live need: the entry is one line, the extra hop is dev-only, and a WAF rule switched on once can be switched on again. `presentError`'s CAPTCHA branch stays for the same reason.

Documentation only — no behaviour change. 297 tests pass.

One measurement left unresolved in the ADR, deliberately: a spoofed Chrome UA draws `502` from awselb from every origin including an approved one, while spoofed Firefox and Safari are served. Read as the WAF catching a UA that contradicts its TLS fingerprint. Confirming it would need a real browser at a real non-`localhost` origin, and it changes nothing here — development against ENCODE works, proxied or direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)