### PR TITLE
Declare the public API surface in code and enforce it with a contract test

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -159,6 +159,30 @@ together with the headers its gate wants. Everything else fetches directly, on
 purpose: a genuine CORS or permissions failure has to stay visible in
 development.
 
+## The public surface
+
+**Public surface** — everything a host app can reach: the names exported from
+`js/index.js`, every member of a browser instance, anything reached through one
+of those members, the coordinator callback names, and the events posted with the
+shape of their payloads. Most of it is *undeclared by construction* —
+`HICBrowser` is not exported, so hosts get instances from `init()` and use them
+directly, and the surface never appears in an export list.
+
+**Manifest** — `js/publicApi.js`, which names that surface as data.
+`test/testPublicApi.js` reads it and fails when a declared name goes missing.
+Nothing imports the manifest at runtime; it exists so there is somewhere to look
+and something that breaks. It supersedes the tables in `docs/adr/0003`.
+
+**The deletion test is not valid against `js/` alone.** Before removing anything
+reachable from a browser instance or from the namespace, check the manifest.
+"No callers in this repo" is half a finding — four members have *no* internal
+callers at all and exist solely for hosts. A name on the manifest is a
+coordinated release across both consumers, not a deletion.
+
+Absence from the manifest lowers the risk of changing something; it does not zero
+it. juicebox.js is published and embeddable by anyone, so for anything resembling
+a load, a session, a state or a lifecycle call, prefer deprecation over deletion.
+
 ## Architecture vocabulary
 
 Refactoring work in this repo uses the deep-module vocabulary: **module**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -171,7 +171,12 @@ directly, and the surface never appears in an export list.
 **Manifest** — `js/publicApi.js`, which names that surface as data.
 `test/testPublicApi.js` reads it and fails when a declared name goes missing.
 Nothing imports the manifest at runtime; it exists so there is somewhere to look
-and something that breaks. It supersedes the tables in `docs/adr/0003`.
+and something that breaks.
+
+The manifest is the source of truth for **what** the surface is. `docs/adr/0003`
+keeps what a list of names cannot carry — *why* the surface is what it is, and
+**which consumer uses what**, which is re-measured at each release. Update both:
+the manifest when the surface changes, the ADR's tables when a consumer does.
 
 **The deletion test is not valid against `js/` alone.** Before removing anything
 reachable from a browser instance or from the namespace, check the manifest.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,27 @@ without a host app.
 The thing the user is looking at. A browser instance shows one primary contact
 map and optionally a **control map** for comparison.
 
+**Dataset** — the source a contact map is drawn from, and the object the browser
+holds (`js/hicDataset.js`). Two kinds, distinguished by `dataset.isLive`:
+
+- a **`.hic` dataset** reads a static file over the network. This is
+  juicebox.js's primary purpose and the case everything is tuned for.
+- a **live contact map** streams from hic-straw instead of reading a file. Built
+  for Spacewalk, which needed contact maps generated as it runs.
+
+**The disguise** — a live contact map is deliberately made to *look like* a
+`.hic` dataset from juicebox.js's side: same `Dataset`, same rendering path, same
+canonical state. This was an expediency, and it mostly works. Where it does not
+hold, say so explicitly rather than treating live as a variant of file:
+
+- `imageTileCore.autoThreshold` takes the 75th percentile rather than the 95th
+  and clamps to 1 for live maps — a real rendering divergence.
+- `loadLiveContactMap` is its own load path, not a parameter to the file path.
+
+The core of this work lives in **hic-straw**, not here; juicebox.js holds a thin
+adapter. When touching it, expect the seam to span three repos. See the
+live-map note on candidate 10 in `docs/architecture-review.html`.
+
 **Canonical state** — the seven fields on `State` (`js/hicState.js`) that fully
 and unambiguously specify the view: `chr1`, `chr2`, `x`, `y`, `zoom`,
 `pixelSize`, `normalization`. Everything else the user sees is derived from

--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -107,6 +107,10 @@ These are contract too, and are easy to miss because they are one dot further ou
 - `layoutController.removeTrackXYPair(pair)` — juicebox-web
 - `layoutController.getContactMatrixViewport()` — Spacewalk
 - `contactMatrixView.update()`, `contactMatrixView.ctx` — Spacewalk
+- `contactMatrixView.viewportElement` — Spacewalk sizes its live-map view from
+  it. **Missed by the measurement above** and found while reviewing #470, which
+  is the argument for the manifest in one line: the table was hand-built and
+  incomplete within a week.
 - `coordinator.addCallback(name, fn)` — Spacewalk registers `onMapLoaded`,
   `onBackgroundColorChange` and `onForegroundColorChange`. The coordinator accepts
   **six** names and throws on anything else, so all six are published behaviour;

--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -1,11 +1,21 @@
 # ADR-0003 — What juicebox.js's public API actually is
 
-**Status:** Accepted
+**Status:** Superseded in part by `js/publicApi.js` (see *Reversal*)
 **Last measured:** 2026-08-06, against `juicebox.js` HEAD, `juicebox-web` `7538049`, `spacewalk` `2776a3a` (both consumers pinned to `v3.6.2`)
 **Related:** #466 (architecture review tracker), ADR-0002
 
 This ADR exists because `docs/architecture-review.html` was written without it, and
 produced at least one wrong verdict as a result. See *Why this was written*.
+
+> **Read `js/publicApi.js` for the surface itself.** Decision 3 below deferred the
+> question of how to mark the surface in code; #470 answered it, and the manifest
+> is now the source of truth. A contract test checks it, so it cannot silently go
+> stale the way the tables below did — two of their entries were already wrong
+> within a week of being measured.
+>
+> What stays here is what a manifest cannot carry: *why* the surface is what it
+> is, which consumer uses what, and the reasoning about third parties. The tables
+> below are kept as the measurement they were, dated, not as a live index.
 
 ## Context
 
@@ -201,10 +211,20 @@ table is sufficient.
 
 ## Reversal
 
-Supersede this when the intended public surface is marked in code (the proposal
-deliberately deferred in decision 3). At that point the contract is machine-checkable
-and a measured table in a Markdown file is the wrong place for it — the ADR becomes
-history, and the marker becomes the source of truth.
+**This has now happened.** #470 marked the surface in code as `js/publicApi.js`,
+enforced by `test/testPublicApi.js`. Per the plan set out here, the manifest is the
+source of truth and this ADR is history: it keeps the reasoning and the
+consumer-usage evidence, and hands the surface itself over.
 
-Until then, this table goes stale the moment either consumer changes. Re-measure it
-at each release rather than trusting it.
+Decision 3 said no `@public` markers, no explicit facade, no export changes. The
+manifest honours all three — it is a declaration, not a wrapper. `HICBrowser` is
+still not exported, and nothing about how hosts obtain a browser changed.
+
+One gap the marker does not close: the events listed above are declared in the
+manifest but not enforced, because proving an event is still *posted* requires
+driving a real map load. That is the `MapLoad` failure mode, and it stays open
+until #438 gives the probe harness a home.
+
+The tables above still go stale the moment either consumer changes. Re-measure
+them at each release rather than trusting them — and when you do, update the
+manifest, not just the tables.

--- a/docs/adr/0003-public-api-contract.md
+++ b/docs/adr/0003-public-api-contract.md
@@ -71,7 +71,7 @@ it is used roughly as intended.
 | `loadLiveContactMap` | — | ✔ | delegation to `dataLoader` |
 | `parseGotoInput` | — | ✔ (3 sites) | delegation to `interactions` |
 | `reset` | ✔ | — | real method |
-| `dataset` | ✔ (3 sites) | ✔ | accessor; SW also reads `.isLiveContactMapDataSet` |
+| `dataset` | ✔ (3 sites) | ✔ | accessor; SW also reads `.isLive` |
 | `activeDataset` | — | ✔ (4 sites) | accessor; SW also reads `.isLive` |
 | `genome` | — | ✔ | truthiness guard only |
 | `id` | — | ✔ (9 sites) | used to build DOM selectors |
@@ -97,8 +97,12 @@ These are contract too, and are easy to miss because they are one dot further ou
 - `layoutController.removeTrackXYPair(pair)` — juicebox-web
 - `layoutController.getContactMatrixViewport()` — Spacewalk
 - `contactMatrixView.update()`, `contactMatrixView.ctx` — Spacewalk
-- `coordinator.addCallback('onMapLoaded' | 'onBackgroundColorChange' | 'onForegroundColorChange', fn)` — Spacewalk
-- `dataset.isLiveContactMapDataSet`, `activeDataset.isLive` — Spacewalk
+- `coordinator.addCallback(name, fn)` — Spacewalk registers `onMapLoaded`,
+  `onBackgroundColorChange` and `onForegroundColorChange`. The coordinator accepts
+  **six** names and throws on anything else, so all six are published behaviour;
+  `onControlMapLoaded`, `onLocusChange` and `onGenomeChange` are registerable and
+  currently unused.
+- `dataset.isLive`, `activeDataset.isLive` — Spacewalk
 
 **Event payloads are contract too.** juicebox-web's `TrackXYPairLoad` /
 `TrackXYPairRemoval` handlers receive the track pair itself and read

--- a/docs/architecture-review.html
+++ b/docs/architecture-review.html
@@ -662,7 +662,7 @@ flowchart TB
         <!-- ---- 10 ---- -->
         <article id="c10" class="space-y-5">
           <div class="flex items-baseline justify-between gap-4 flex-wrap">
-            <h3 class="font-serif text-2xl">10 · One dataset-load path behind one interface</h3>
+            <h3 class="font-serif text-2xl">10 · One dataset-load path — <em>this is the live-map seam</em></h3>
             <div class="flex gap-2 shrink-0">
               <span class="text-xs uppercase tracking-wider px-2 py-1 rounded bg-white border border-slate-300 text-slate-600">Open</span>
               <span class="text-xs uppercase tracking-wider px-2 py-1 rounded bg-amber-100 text-amber-900">Worth exploring</span>
@@ -729,7 +729,19 @@ flowchart TB
           </ul>
           <div class="rounded border border-sky-300 bg-sky-50 px-4 py-3 text-sm text-sky-900 space-y-1">
             <div class="text-xs uppercase tracking-wider opacity-70">Consumer impact — three named entry points must survive</div>
-            <div><span class="font-mono">loadHicFile</span> (both apps), <span class="font-mono">loadHicControlFile</span> (juicebox-web) and <span class="font-mono">loadLiveContactMap</span> (Spacewalk) are three distinct public calls with three signatures. Collapsing them onto one internal <span class="font-mono">loadMap(source, role)</span> is fine — the three named methods on <span class="font-mono">HICBrowser</span> are not optional, and their argument shapes are contract. <br><br>Spacewalk passes <span class="font-mono">{liveContactMap, name, locus}</span>; juicebox-web passes <span class="font-mono">{url, name, nvi, ...}</span>.</div>
+            <div><span class="font-mono">loadHicFile</span> (both apps), <span class="font-mono">loadHicControlFile</span> (juicebox-web) and <span class="font-mono">loadLiveContactMap</span> (Spacewalk) are three distinct public calls with three signatures. Collapsing them onto one internal <span class="font-mono">loadMap(source, role)</span> is fine — the three named methods on <span class="font-mono">HICBrowser</span> are not optional, and their argument shapes are contract. <br><br>Spacewalk passes <span class="font-mono">{liveContactMap, name, locus}</span>; juicebox-web passes <span class="font-mono">{url, name, nvi, ...}</span>. All three are declared in <span class="font-mono">js/publicApi.js</span>; removing one fails <span class="font-mono">test/testPublicApi.js</span>.</div>
+          </div>
+
+          <div class="rounded border border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-950 space-y-2">
+            <div class="text-xs uppercase tracking-wider opacity-70">Read this before scoping — what the card's title hides</div>
+            <p>This candidate <strong>is the live contact map seam</strong>, and the seam was built as an expediency: the goal was to make a live map, streamed from hic-straw, look to juicebox.js like a file-based <span class="font-mono">.hic</span> map. The disguise is deliberate and mostly successful — but "one load path" means <em>deciding whether the disguise was the right call</em>, not just deduplicating three method bodies.</p>
+            <p>The debt spans three repos. The core work lives in <span class="font-mono">hic-straw</span> (which is not in the architecture review at all) and in Spacewalk; what reached juicebox.js is a thin adapter. Narrow, but it leaks in exactly three places:</p>
+            <ul class="list-disc list-inside space-y-1">
+              <li><span class="font-mono">js/hicDataset.js</span> — <span class="font-mono">isLive</span> is set from config and <span class="font-mono">datasetType</span> derived from it. Both are consumer contract; Spacewalk branches on <span class="font-mono">dataset.isLive</span>.</li>
+              <li><span class="font-mono">js/imageTileCore.js</span> — <span class="font-mono">autoThreshold</span> takes the 75th percentile instead of the 95th and clamps to 1 for live maps. <strong>A genuine rendering divergence</strong>, not an adapter detail: the disguise does not hold here, and any change to the load path has to keep this branch reachable.</li>
+              <li><span class="font-mono">js/dataLoader.js</span> — <span class="font-mono">loadLiveContactMap</span> as a separate path, with the state ladder duplicated from <span class="font-mono">loadHicFile</span>.</li>
+            </ul>
+            <p>Two live artefacts of the churn, both worth reading first: <strong>#471</strong> (the <span class="font-mono">datasetType</span> vocabulary collision this seam created), and the fact that ADR-0003 cited a dataset flag named <span class="font-mono">isLiveContactMapDataSet</span> that exists in no repo — a rename that left a stale reference in a document written the same week.</p>
           </div>
 
         </article>

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -74,3 +74,48 @@ export const NAMESPACE_SURFACE = [
     'EventBus',
     'setUrlMapper'
 ]
+
+/**
+ * Browser instance members that exist as soon as a browser is constructed.
+ *
+ * This is the undeclared half of the contract, and the reason this file exists.
+ * `HICBrowser` is not exported; hosts receive instances from `init()`,
+ * `createBrowser()` or `getCurrentBrowser()` and use them directly.
+ *
+ * Five of these -- the four load methods and `parseGotoInput` -- forward to an
+ * internal collaborator without adding behaviour, and four of those have no
+ * internal callers at all: they exist solely for hosts. They look like
+ * deletable indirection from inside this repo and are not. Removing them would
+ * not remove a hop, it would promote the collaborators they delegate to from
+ * internal detail to published name, freezing this decomposition into the
+ * contract. See #467.
+ *
+ * Seven more are assigned in the constructor rather than declared on the
+ * prototype, so they are invisible to any check that reflects on the class
+ * instead of building an instance.
+ */
+export const BROWSER_SURFACE = [
+    // Delegating loaders and lookups -- no internal callers, hosts only
+    'loadHicFile',
+    'loadTracks',
+    'loadHicControlFile',
+    'loadLiveContactMap',
+    'parseGotoInput',
+
+    // Real methods
+    'reset',
+    'setCustomCrosshairsHandler',
+
+    // Accessors -- present from construction, populated by a load
+    'dataset',
+    'activeDataset',
+
+    // Constructor-assigned fields
+    'id',
+    'config',
+    'rootElement',
+    'eventBus',
+    'coordinator',
+    'layoutController',
+    'contactMatrixView'
+]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -1,0 +1,76 @@
+/*
+ *  The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 The Regents of the University of California
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * The declared public surface of juicebox.js.
+ *
+ * juicebox.js is an embeddable component, not an application. Its correctness
+ * condition is not "the dev harness still works" -- it is "the host apps still
+ * work, and so does an embedder we have never heard of."
+ *
+ * Most of that surface is not visible from inside this repo. `js/index.js`
+ * exports twelve names and `HICBrowser` is not one of them: hosts get browser
+ * instances from `init()` and then use them directly. So asking "does anything
+ * call this?" and grepping `js/` returns *no* for members two shipped
+ * applications depend on. Every refactor that trusts that grep is reasoning
+ * from a false negative -- and one already has, see ADR-0003.
+ *
+ * This module is the fix. It names the surface as data so there is somewhere to
+ * look, and `test/testPublicApi.js` reads it so there is something that breaks.
+ *
+ * **A name in this file is a promise.** Renaming it, removing it, or changing
+ * its signature or return type is a breaking change requiring a coordinated
+ * release across both known consumers -- see the release ceremony.
+ *
+ * **Absence from this file is not permission.** juicebox.js is MIT, published
+ * and embeddable by anyone; the consumers we can measure are not the
+ * population. For anything resembling a load, a session, a state or a
+ * lifecycle call, prefer deprecation over deletion even when this file is
+ * silent. For genuinely internal machinery, this file is sufficient.
+ *
+ * Nothing imports this module at runtime. It ships with the library so that
+ * consumers and future refactors can read it, and bundlers drop it from
+ * consumer builds.
+ */
+
+/**
+ * Names exported from `js/index.js`.
+ *
+ * This half of the contract is healthy: it is declared in an explicit export
+ * block and used roughly as intended. It is listed here so the whole surface
+ * sits in one place, and so the test can check both directions -- an addition
+ * here is as much a contract change as a removal.
+ */
+export const NAMESPACE_SURFACE = [
+    'version',
+    'init',
+    'toJSON',
+    'restoreSession',
+    'compressedSession',
+    'createBrowser',
+    'getCurrentBrowser',
+    'setCurrentBrowser',
+    'getAllBrowsers',
+    'igvxhr',
+    'EventBus',
+    'setUrlMapper'
+]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -119,3 +119,23 @@ export const BROWSER_SURFACE = [
     'layoutController',
     'contactMatrixView'
 ]
+
+/**
+ * Surface that does not exist until a map has loaded.
+ *
+ * These are contract exactly like `BROWSER_SURFACE`, but they cannot be
+ * asserted against a freshly constructed browser: nothing assigns them until a
+ * dataset arrives. `genome`, for instance, is set by the data loader, and
+ * Spacewalk guards on its presence.
+ *
+ * They are declared separately rather than dropped, because the whole failure
+ * this file addresses is that undeclared surface is invisible surface. A member
+ * that is hard to test is not thereby less of a promise.
+ *
+ * Each entry names the path a host reads and where it is populated.
+ */
+export const POST_LOAD_SURFACE = [
+    {path: 'browser.genome', populatedBy: 'dataLoader, on map load'},
+    {path: 'browser.dataset.isLive', populatedBy: 'the Dataset constructor'},
+    {path: 'browser.activeDataset.isLive', populatedBy: 'the Dataset constructor'}
+]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -47,9 +47,9 @@
  * lifecycle call, prefer deprecation over deletion even when this file is
  * silent. For genuinely internal machinery, this file is sufficient.
  *
- * Nothing imports this module at runtime. It ships with the library so that
- * consumers and future refactors can read it, and bundlers drop it from
- * consumer builds.
+ * Nothing imports this module at runtime, so it never reaches a consumer
+ * bundle. It is not in `package.json`'s `files` either -- this is repo source,
+ * read here or on GitHub, not something an installed package exposes.
  */
 
 /**
@@ -156,6 +156,10 @@ export const SUB_SURFACES = [
     {owner: 'layoutController', member: 'getContactMatrixViewport'},
     {owner: 'contactMatrixView', member: 'update'},
     {owner: 'contactMatrixView', member: 'ctx'},
+    // Spacewalk sizes its live-map view from this element. Missing from
+    // ADR-0003's measurement and found while reviewing #470 -- which is the
+    // point: a hand-measured table missed it, and a test would not have.
+    {owner: 'contactMatrixView', member: 'viewportElement'},
     {owner: 'coordinator', member: 'addCallback'}
 ]
 

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -139,3 +139,22 @@ export const POST_LOAD_SURFACE = [
     {path: 'browser.dataset.isLive', populatedBy: 'the Dataset constructor'},
     {path: 'browser.activeDataset.isLive', populatedBy: 'the Dataset constructor'}
 ]
+
+/**
+ * Contract reached one dot further out, through a member of `BROWSER_SURFACE`.
+ *
+ * These are the easiest part of the surface to miss, because nothing about them
+ * looks public from the browser's own member list: a host that holds
+ * `browser.layoutController` can call anything on it, and two do. Handing back
+ * an internal collaborator publishes the parts of it that get used.
+ *
+ * `owner` is the browser member the host reaches through; `member` is what it
+ * uses on the far side.
+ */
+export const SUB_SURFACES = [
+    {owner: 'layoutController', member: 'removeTrackXYPair'},
+    {owner: 'layoutController', member: 'getContactMatrixViewport'},
+    {owner: 'contactMatrixView', member: 'update'},
+    {owner: 'contactMatrixView', member: 'ctx'},
+    {owner: 'coordinator', member: 'addCallback'}
+]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -183,3 +183,51 @@ export const COORDINATOR_CALLBACKS = [
     'onBackgroundColorChange',
     'onForegroundColorChange'
 ]
+
+/**
+ * Events juicebox.js posts, and the bus each travels on.
+ *
+ * The event bus is the sharpest case in the whole contract. Every internal
+ * subscription was migrated to the coordinator, so from inside this repo the
+ * bus looks dead -- and from outside it is load-bearing: five of these have
+ * external subscribers and no internal ones. A review that counted subscribers
+ * by grepping `js/` concluded the per-browser bus had none, which was true of
+ * this repo and false of the product.
+ *
+ * **These names are declared but not enforced.** The test asserts the plumbing
+ * they travel over, not that each is still posted -- proving an event still
+ * fires means driving a real map load and watching the bus, which needs the
+ * probe harness of #438.
+ *
+ * That is a real gap, and it is worth naming precisely: juicebox-web subscribed
+ * to a `MapLoad` event that stopped being posted in December 2025 and nobody
+ * noticed for eight months. Nothing in this file would catch that happening
+ * again. Removing a name here is caught by review; removing the *post* that
+ * feeds it is not.
+ */
+export const EVENTS_POSTED = [
+    {name: 'GenomeChange', bus: 'global'},
+    {name: 'BrowserSelect', bus: 'global'},
+    {name: 'TrackXYPairLoad', bus: 'global'},
+    {name: 'TrackXYPairRemoval', bus: 'global'},
+    {name: 'DidHideCrosshairs', bus: 'browser'},
+    {name: 'DidShowCrosshairs', bus: 'browser'},
+    {name: 'DragStopped', bus: 'browser'}
+]
+
+/**
+ * Event payload shape that a host reads into.
+ *
+ * `TrackXYPairLoad` and `TrackXYPairRemoval` carry the track pair itself.
+ * juicebox-web reads the track and its config format off the payload, then
+ * hands the same object back to `layoutController.removeTrackXYPair`. So the
+ * payload's internals are published shape, not an implementation detail -- a
+ * refactor that changed what a track pair looks like would break a host that
+ * never named the type.
+ *
+ * Declaration only; verifying it means posting a real track load.
+ */
+export const EVENT_PAYLOAD_SHAPES = [
+    {event: 'TrackXYPairLoad', payload: 'the TrackPair itself', readsInto: ['track', 'track.name', 'track.config.format']},
+    {event: 'TrackXYPairRemoval', payload: 'the TrackPair itself', readsInto: ['track', 'track.name', 'track.config.format']}
+]

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -158,3 +158,28 @@ export const SUB_SURFACES = [
     {owner: 'contactMatrixView', member: 'ctx'},
     {owner: 'coordinator', member: 'addCallback'}
 ]
+
+/**
+ * Event names accepted by `browser.coordinator.addCallback(name, fn)`.
+ *
+ * This is the host extension point -- how an embedder learns about map loads,
+ * locus changes and colour changes without subscribing to the event bus. See
+ * ADR-0002 for why the coordinator is not going away.
+ *
+ * All six are declared, not just the three a known consumer happens to use
+ * today: `addCallback` throws on an unrecognised name, so the set it accepts is
+ * already published behaviour. Narrowing it would break a host that registered
+ * one of the other three, silently and only at runtime.
+ *
+ * The coordinator got here on its own -- it validates against its own declared
+ * list and throws. That is the only self-describing, self-enforcing piece of
+ * the browser contract, and it is the pattern this whole module generalises.
+ */
+export const COORDINATOR_CALLBACKS = [
+    'onMapLoaded',
+    'onControlMapLoaded',
+    'onLocusChange',
+    'onGenomeChange',
+    'onBackgroundColorChange',
+    'onForegroundColorChange'
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,234 @@
         "igv": "3.8.5",
         "igv-ui": "github:igvteam/igv-ui#v1.5.9",
         "igv-utils": "github:igvteam/igv-utils#v1.7.1",
+        "jsdom": "^29.1.1",
         "sass": "^1.93.3",
         "vite": "^8.0.0",
         "vite-plugin-static-copy": "^4.0.0",
         "vitest": "^4.0.7",
         "w3c-xmlhttprequest": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -797,6 +1020,16 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -869,6 +1102,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -879,6 +1126,27 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -887,6 +1155,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1048,6 +1329,19 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/igv": {
       "version": "3.8.5",
       "resolved": "https://registry.npmjs.org/igv/-/igv-3.8.5.tgz",
@@ -1118,6 +1412,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -1381,6 +1723,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1390,6 +1742,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -1505,6 +1864,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1561,6 +1933,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -1573,6 +1955,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1629,6 +2021,19 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1672,6 +2077,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1719,6 +2131,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1740,6 +2172,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -1994,6 +2462,19 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2002,6 +2483,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -2020,6 +2536,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "igv": "3.8.5",
     "igv-ui": "github:igvteam/igv-ui#v1.5.9",
     "igv-utils": "github:igvteam/igv-utils#v1.7.1",
+    "jsdom": "^29.1.1",
     "sass": "^1.93.3",
     "vite": "^8.0.0",
     "vite-plugin-static-copy": "^4.0.0",

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -1,5 +1,7 @@
-import {describe, it, expect} from 'vitest'
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
 import juicebox from '../js/index.js'
+import HICBrowser from '../js/hicBrowser.js'
+import {withDOM} from './utils/browserFixture.js'
 import {NAMESPACE_SURFACE} from '../js/publicApi.js'
 
 /**
@@ -28,5 +30,24 @@ describe('namespace surface', () => {
         // already healthy, so the reverse check costs nothing here -- unlike the
         // browser instance, where it would mean classifying every member.
         expect(Object.keys(juicebox).sort()).toEqual([...NAMESPACE_SURFACE].sort())
+    })
+})
+
+describe('browser instance surface', () => {
+
+    let fixture
+    let browser
+
+    beforeEach(() => {
+        fixture = withDOM()
+        browser = new HICBrowser(fixture.container, {})
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    it('constructs a browser', () => {
+        expect(browser.id).toMatch(/^browser_/)
     })
 })

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -19,6 +19,29 @@ import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES, COO
  * member does not fail the build. See issue #470.
  */
 
+/**
+ * Stand up a fresh browser around each test in the calling describe, and tear
+ * the DOM back down afterwards. Returns a holder rather than the browser itself
+ * because the instance does not exist until beforeEach runs.
+ */
+function withBrowser() {
+
+    const context = {browser: undefined}
+    let fixture
+
+    beforeEach(() => {
+        fixture = withDOM()
+        context.browser = new HICBrowser(fixture.container, {})
+    })
+
+    afterEach(() => {
+        fixture.restore()
+        context.browser = undefined
+    })
+
+    return context
+}
+
 describe('namespace surface', () => {
 
     it('exports every declared name', () => {
@@ -37,20 +60,10 @@ describe('namespace surface', () => {
 
 describe('browser instance surface', () => {
 
-    let fixture
-    let browser
-
-    beforeEach(() => {
-        fixture = withDOM()
-        browser = new HICBrowser(fixture.container, {})
-    })
-
-    afterEach(() => {
-        fixture.restore()
-    })
+    const context = withBrowser()
 
     it('constructs a browser', () => {
-        expect(browser.id).toMatch(/^browser_/)
+        expect(context.browser.id).toMatch(/^browser_/)
     })
 
     it('exposes every declared member', () => {
@@ -58,7 +71,7 @@ describe('browser instance surface', () => {
             // `in` rather than a truthiness check: `dataset` and `activeDataset`
             // are accessors that exist from construction and stay undefined
             // until a map loads. Presence is the contract, not the value.
-            expect(name in browser, `browser no longer exposes "${name}"`).toBe(true)
+            expect(name in context.browser, `browser no longer exposes "${name}"`).toBe(true)
         }
     })
 })
@@ -91,22 +104,12 @@ describe('post-load surface', () => {
 
 describe('sub-surfaces', () => {
 
-    let fixture
-    let browser
-
-    beforeEach(() => {
-        fixture = withDOM()
-        browser = new HICBrowser(fixture.container, {})
-    })
-
-    afterEach(() => {
-        fixture.restore()
-    })
+    const context = withBrowser()
 
     it('exposes every declared member on its owner', () => {
         for (const {owner, member} of SUB_SURFACES) {
-            expect(browser[owner], `browser no longer exposes "${owner}"`).toBeDefined()
-            expect(member in browser[owner], `browser.${owner} no longer exposes "${member}"`).toBe(true)
+            expect(context.browser[owner], `browser no longer exposes "${owner}"`).toBeDefined()
+            expect(member in context.browser[owner], `browser.${owner} no longer exposes "${member}"`).toBe(true)
         }
     })
 
@@ -121,17 +124,7 @@ describe('sub-surfaces', () => {
 
 describe('coordinator callbacks', () => {
 
-    let fixture
-    let browser
-
-    beforeEach(() => {
-        fixture = withDOM()
-        browser = new HICBrowser(fixture.container, {})
-    })
-
-    afterEach(() => {
-        fixture.restore()
-    })
+    const context = withBrowser()
 
     // Exercised rather than reflected on: addCallback validates its argument and
     // throws, so these assertions test behaviour a host can actually observe.
@@ -139,44 +132,34 @@ describe('coordinator callbacks', () => {
     it('accepts every declared callback name', () => {
         for (const name of COORDINATOR_CALLBACKS) {
             expect(
-                () => browser.coordinator.addCallback(name, () => {}),
+                () => context.browser.coordinator.addCallback(name, () => {}),
                 `coordinator no longer accepts "${name}"`
             ).not.toThrow()
         }
     })
 
     it('rejects an undeclared callback name', () => {
-        expect(() => browser.coordinator.addCallback('onSomethingUndeclared', () => {})).toThrow()
+        expect(() => context.browser.coordinator.addCallback('onSomethingUndeclared', () => {})).toThrow()
     })
 
     it('returns an unsubscribe function', () => {
         // Hosts hold this to detach on teardown; dropping it would leak the
         // callback and outlive the host's own lifecycle.
-        const unsubscribe = browser.coordinator.addCallback('onMapLoaded', () => {})
+        const unsubscribe = context.browser.coordinator.addCallback('onMapLoaded', () => {})
         expect(typeof unsubscribe).toBe('function')
     })
 })
 
 describe('event bus', () => {
 
-    let fixture
-    let browser
-
-    beforeEach(() => {
-        fixture = withDOM()
-        browser = new HICBrowser(fixture.container, {})
-    })
-
-    afterEach(() => {
-        fixture.restore()
-    })
+    const context = withBrowser()
 
     // These check the plumbing declared events travel over. Whether each event
     // is still *posted* is not checked -- see EVENTS_POSTED and #438.
 
     it('exposes a per-browser bus that a host can subscribe to', () => {
-        expect(typeof browser.eventBus.subscribe).toBe('function')
-        expect(typeof browser.eventBus.post).toBe('function')
+        expect(typeof context.browser.eventBus.subscribe).toBe('function')
+        expect(typeof context.browser.eventBus.post).toBe('function')
     })
 
     it('exposes a global bus', () => {
@@ -184,19 +167,15 @@ describe('event bus', () => {
         expect(typeof EventBus.globalBus.subscribe).toBe('function')
     })
 
-    it('delivers a posted event to a subscriber on the declared bus', () => {
-        for (const {name, bus} of EVENTS_POSTED) {
-            const target = 'global' === bus ? EventBus.globalBus : browser.eventBus
-            let received
-            target.subscribe(name, event => { received = event })
-            target.post({type: name, data: 'payload'})
-            expect(received, `"${name}" did not reach a subscriber on the ${bus} bus`).toBeDefined()
-        }
-    })
-
-    it('names a bus for every declared event', () => {
+    it('reaches a subscriber on whichever bus an event declares', () => {
+        // Deliberately not a check that juicebox still posts these -- this test
+        // does the posting, so it could only ever pass. It checks the weaker
+        // thing that is still worth knowing: that the bus each declared event
+        // names is real and reachable from what a host holds.
         for (const {name, bus} of EVENTS_POSTED) {
             expect(['global', 'browser'], `"${name}" declares an unknown bus`).toContain(bus)
+            const target = 'global' === bus ? EventBus.globalBus : context.browser.eventBus
+            expect(typeof target.subscribe, `the ${bus} bus is not subscribable`).toBe('function')
         }
     })
 

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -1,0 +1,32 @@
+import {describe, it, expect} from 'vitest'
+import juicebox from '../js/index.js'
+import {NAMESPACE_SURFACE} from '../js/publicApi.js'
+
+/**
+ * Contract tests for the declared public surface.
+ *
+ * These assert what a *host application* can observe: that a name a host writes
+ * is reachable on the object the host was handed. They deliberately say nothing
+ * about how a member is implemented, whether it delegates, or where it is
+ * declared -- a test that broke when a member moved from the prototype to the
+ * constructor would be testing implementation, and would be wrong.
+ *
+ * The check runs one way: every declared name must exist. A new undeclared
+ * member does not fail the build. See issue #470.
+ */
+
+describe('namespace surface', () => {
+
+    it('exports every declared name', () => {
+        for (const name of NAMESPACE_SURFACE) {
+            expect(juicebox, `js/index.js no longer exports "${name}"`).toHaveProperty(name)
+        }
+    })
+
+    it('exports nothing beyond the declared names', () => {
+        // js/index.js is an explicit export block that is already declared and
+        // already healthy, so the reverse check costs nothing here -- unlike the
+        // browser instance, where it would mean classifying every member.
+        expect(Object.keys(juicebox).sort()).toEqual([...NAMESPACE_SURFACE].sort())
+    })
+})

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -2,7 +2,7 @@ import {describe, it, expect, beforeEach, afterEach} from 'vitest'
 import juicebox from '../js/index.js'
 import HICBrowser from '../js/hicBrowser.js'
 import {withDOM} from './utils/browserFixture.js'
-import {NAMESPACE_SURFACE} from '../js/publicApi.js'
+import {NAMESPACE_SURFACE, BROWSER_SURFACE} from '../js/publicApi.js'
 
 /**
  * Contract tests for the declared public surface.
@@ -49,5 +49,14 @@ describe('browser instance surface', () => {
 
     it('constructs a browser', () => {
         expect(browser.id).toMatch(/^browser_/)
+    })
+
+    it('exposes every declared member', () => {
+        for (const name of BROWSER_SURFACE) {
+            // `in` rather than a truthiness check: `dataset` and `activeDataset`
+            // are accessors that exist from construction and stay undefined
+            // until a map loads. Presence is the contract, not the value.
+            expect(name in browser, `browser no longer exposes "${name}"`).toBe(true)
+        }
     })
 })

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -3,7 +3,7 @@ import juicebox from '../js/index.js'
 import HICBrowser from '../js/hicBrowser.js'
 import {withDOM} from './utils/browserFixture.js'
 import {HiCDataset} from '../js/hicDataset.js'
-import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES} from '../js/publicApi.js'
+import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES, COORDINATOR_CALLBACKS} from '../js/publicApi.js'
 
 /**
  * Contract tests for the declared public surface.
@@ -115,5 +115,43 @@ describe('sub-surfaces', () => {
         for (const {owner} of SUB_SURFACES) {
             expect(BROWSER_SURFACE, `"${owner}" is a sub-surface owner but is not declared surface`).toContain(owner)
         }
+    })
+})
+
+describe('coordinator callbacks', () => {
+
+    let fixture
+    let browser
+
+    beforeEach(() => {
+        fixture = withDOM()
+        browser = new HICBrowser(fixture.container, {})
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    // Exercised rather than reflected on: addCallback validates its argument and
+    // throws, so these assertions test behaviour a host can actually observe.
+
+    it('accepts every declared callback name', () => {
+        for (const name of COORDINATOR_CALLBACKS) {
+            expect(
+                () => browser.coordinator.addCallback(name, () => {}),
+                `coordinator no longer accepts "${name}"`
+            ).not.toThrow()
+        }
+    })
+
+    it('rejects an undeclared callback name', () => {
+        expect(() => browser.coordinator.addCallback('onSomethingUndeclared', () => {})).toThrow()
+    })
+
+    it('returns an unsubscribe function', () => {
+        // Hosts hold this to detach on teardown; dropping it would leak the
+        // callback and outlive the host's own lifecycle.
+        const unsubscribe = browser.coordinator.addCallback('onMapLoaded', () => {})
+        expect(typeof unsubscribe).toBe('function')
     })
 })

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -3,7 +3,7 @@ import juicebox from '../js/index.js'
 import HICBrowser from '../js/hicBrowser.js'
 import {withDOM} from './utils/browserFixture.js'
 import {HiCDataset} from '../js/hicDataset.js'
-import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE} from '../js/publicApi.js'
+import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES} from '../js/publicApi.js'
 
 /**
  * Contract tests for the declared public surface.
@@ -85,5 +85,35 @@ describe('post-load surface', () => {
         // be checked rather than only declared.
         const dataset = new HiCDataset({url: 'https://example.com/nonexistent.hic'})
         expect('isLive' in dataset).toBe(true)
+    })
+})
+
+describe('sub-surfaces', () => {
+
+    let fixture
+    let browser
+
+    beforeEach(() => {
+        fixture = withDOM()
+        browser = new HICBrowser(fixture.container, {})
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    it('exposes every declared member on its owner', () => {
+        for (const {owner, member} of SUB_SURFACES) {
+            expect(browser[owner], `browser no longer exposes "${owner}"`).toBeDefined()
+            expect(member in browser[owner], `browser.${owner} no longer exposes "${member}"`).toBe(true)
+        }
+    })
+
+    it('declares owners that are themselves declared surface', () => {
+        // A sub-surface reached through an undeclared member would be a promise
+        // resting on nothing.
+        for (const {owner} of SUB_SURFACES) {
+            expect(BROWSER_SURFACE, `"${owner}" is a sub-surface owner but is not declared surface`).toContain(owner)
+        }
     })
 })

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -3,7 +3,8 @@ import juicebox from '../js/index.js'
 import HICBrowser from '../js/hicBrowser.js'
 import {withDOM} from './utils/browserFixture.js'
 import {HiCDataset} from '../js/hicDataset.js'
-import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES, COORDINATOR_CALLBACKS} from '../js/publicApi.js'
+import EventBus from '../js/eventBus.js'
+import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE, SUB_SURFACES, COORDINATOR_CALLBACKS, EVENTS_POSTED, EVENT_PAYLOAD_SHAPES} from '../js/publicApi.js'
 
 /**
  * Contract tests for the declared public surface.
@@ -153,5 +154,56 @@ describe('coordinator callbacks', () => {
         // callback and outlive the host's own lifecycle.
         const unsubscribe = browser.coordinator.addCallback('onMapLoaded', () => {})
         expect(typeof unsubscribe).toBe('function')
+    })
+})
+
+describe('event bus', () => {
+
+    let fixture
+    let browser
+
+    beforeEach(() => {
+        fixture = withDOM()
+        browser = new HICBrowser(fixture.container, {})
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    // These check the plumbing declared events travel over. Whether each event
+    // is still *posted* is not checked -- see EVENTS_POSTED and #438.
+
+    it('exposes a per-browser bus that a host can subscribe to', () => {
+        expect(typeof browser.eventBus.subscribe).toBe('function')
+        expect(typeof browser.eventBus.post).toBe('function')
+    })
+
+    it('exposes a global bus', () => {
+        expect(EventBus.globalBus).toBeDefined()
+        expect(typeof EventBus.globalBus.subscribe).toBe('function')
+    })
+
+    it('delivers a posted event to a subscriber on the declared bus', () => {
+        for (const {name, bus} of EVENTS_POSTED) {
+            const target = 'global' === bus ? EventBus.globalBus : browser.eventBus
+            let received
+            target.subscribe(name, event => { received = event })
+            target.post({type: name, data: 'payload'})
+            expect(received, `"${name}" did not reach a subscriber on the ${bus} bus`).toBeDefined()
+        }
+    })
+
+    it('names a bus for every declared event', () => {
+        for (const {name, bus} of EVENTS_POSTED) {
+            expect(['global', 'browser'], `"${name}" declares an unknown bus`).toContain(bus)
+        }
+    })
+
+    it('declares a payload shape only for events it also posts', () => {
+        const posted = EVENTS_POSTED.map(entry => entry.name)
+        for (const {event} of EVENT_PAYLOAD_SHAPES) {
+            expect(posted, `"${event}" has a declared payload but is not a declared event`).toContain(event)
+        }
     })
 })

--- a/test/testPublicApi.js
+++ b/test/testPublicApi.js
@@ -2,7 +2,8 @@ import {describe, it, expect, beforeEach, afterEach} from 'vitest'
 import juicebox from '../js/index.js'
 import HICBrowser from '../js/hicBrowser.js'
 import {withDOM} from './utils/browserFixture.js'
-import {NAMESPACE_SURFACE, BROWSER_SURFACE} from '../js/publicApi.js'
+import {HiCDataset} from '../js/hicDataset.js'
+import {NAMESPACE_SURFACE, BROWSER_SURFACE, POST_LOAD_SURFACE} from '../js/publicApi.js'
 
 /**
  * Contract tests for the declared public surface.
@@ -58,5 +59,31 @@ describe('browser instance surface', () => {
             // until a map loads. Presence is the contract, not the value.
             expect(name in browser, `browser no longer exposes "${name}"`).toBe(true)
         }
+    })
+})
+
+describe('post-load surface', () => {
+
+    it('declares where each member is populated', () => {
+        for (const entry of POST_LOAD_SURFACE) {
+            expect(entry.path).toBeTruthy()
+            expect(entry.populatedBy, `${entry.path} does not say what populates it`).toBeTruthy()
+        }
+    })
+
+    it('keeps genome out of the construction-time surface', () => {
+        // The split is deliberate. genome is assigned by the data loader, so
+        // folding it into BROWSER_SURFACE would fail against a bare instance --
+        // and the tempting fix, dropping it, would make real contract invisible.
+        expect(BROWSER_SURFACE).not.toContain('genome')
+        expect(POST_LOAD_SURFACE.map(entry => entry.path)).toContain('browser.genome')
+    })
+
+    it('exposes isLive on a dataset', () => {
+        // Spacewalk reads this to tell a live contact map from a static .hic.
+        // A dataset constructs without a browser, so unlike genome this one can
+        // be checked rather than only declared.
+        const dataset = new HiCDataset({url: 'https://example.com/nonexistent.hic'})
+        expect('isLive' in dataset).toBe(true)
     })
 })

--- a/test/utils/browserFixture.js
+++ b/test/utils/browserFixture.js
@@ -1,0 +1,93 @@
+/**
+ * Build a real HICBrowser instance for contract tests.
+ *
+ * Most of the public surface is not on `HICBrowser.prototype` -- seven of the
+ * members hosts use are assigned in the constructor -- so checking the contract
+ * means constructing an instance, not reflecting on a class.
+ *
+ * Two obstacles, both handled here:
+ *
+ * 1. `test/setup.js` installs a hand-rolled `document` mock for the node-based
+ *    tests. Rather than fight it with a per-file vitest environment, this helper
+ *    stands up its own JSDOM and swaps the globals for the duration of the test,
+ *    restoring them afterwards. The existing suite is untouched either way.
+ *
+ * 2. The constructor reaches a canvas immediately: `createWidgets()` builds a
+ *    ContactMatrixView whose constructor calls `getContext('2d')`, as do the
+ *    ruler and the track renderer. JSDOM returns null there unless the native
+ *    `canvas` package is installed. These tests need construction to succeed,
+ *    not pixels to be correct, so the 2D context is stubbed with an inert
+ *    object instead of pulling in a native build.
+ */
+
+import {JSDOM} from 'jsdom'
+
+/**
+ * An inert 2D context. Every method is a no-op and every property is writable,
+ * which is all the constructors need -- nothing here is asserted against.
+ */
+function stubContext2D() {
+    const noop = () => {}
+    return new Proxy({
+        canvas: undefined,
+        fillStyle: '#000000',
+        strokeStyle: '#000000',
+        lineWidth: 1,
+        font: '10px sans-serif',
+        globalAlpha: 1,
+        measureText: () => ({width: 0}),
+        getImageData: () => ({data: new Uint8ClampedArray(4), width: 1, height: 1}),
+        createImageData: () => ({data: new Uint8ClampedArray(4), width: 1, height: 1})
+    }, {
+        get: (target, prop) => prop in target ? target[prop] : noop,
+        set: (target, prop, value) => {
+            target[prop] = value
+            return true
+        }
+    })
+}
+
+const SWAPPED_GLOBALS = ['window', 'document', 'navigator', 'HTMLElement', 'HTMLCanvasElement', 'Node', 'Element', 'Image', 'getComputedStyle', 'devicePixelRatio']
+
+/**
+ * Install a JSDOM window over the current globals and return a restore function
+ * plus a container element ready to hand to the HICBrowser constructor.
+ */
+export function withDOM() {
+
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {pretendToBeVisual: true})
+    const {window} = dom
+
+    window.HTMLCanvasElement.prototype.getContext = function () {
+        const ctx = stubContext2D()
+        ctx.canvas = this
+        return ctx
+    }
+
+    const saved = new Map()
+    for (const key of SWAPPED_GLOBALS) {
+        saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+        Object.defineProperty(globalThis, key, {
+            value: key === 'window' ? window : window[key],
+            writable: true,
+            configurable: true
+        })
+    }
+
+    const container = window.document.createElement('div')
+    window.document.body.appendChild(container)
+
+    const restore = () => {
+        for (const key of SWAPPED_GLOBALS) {
+            const descriptor = saved.get(key)
+            if (descriptor) {
+                Object.defineProperty(globalThis, key, descriptor)
+            } else {
+                delete globalThis[key]
+            }
+        }
+        window.close()
+    }
+
+    return {window, container, restore}
+}


### PR DESCRIPTION
Closes #470.

Declares juicebox.js's public surface as data in `js/publicApi.js`, and enforces it
with `test/testPublicApi.js` (16 tests) against a real `HICBrowser` built under JSDOM.

**No behaviour changes.** Nothing is renamed, removed, moved or re-signatured.
`HICBrowser` is still not exported and nothing about how hosts obtain a browser
changed. This adds a declaration, a test, and documentation.

## Why

`js/index.js` exports twelve names and `HICBrowser` is not one of them — hosts get
instances from `init()` and use them directly. So the surface two shipped apps
depend on is declared nowhere, and "does anything call this?" answered by grepping
`js/` returns *no* for members juicebox-web and Spacewalk rely on.

That has already cost twice: juicebox-web's `MapLoad` subscription has been silently
dead for eight months, and the architecture review recorded the per-browser event bus
as having zero subscribers — true of this repo, false of the product. Five of the
review's eight remaining candidates were scoped as safe on that basis.

ADR-0003 measured the surface into a Markdown table but deliberately deferred the
question of how to mark it in code. This is that decision.

## What's declared

| Group | Count | Enforced how |
|---|---|---|
| `NAMESPACE_SURFACE` | 12 | Both directions against `js/index.js` |
| `BROWSER_SURFACE` | 16 | Presence on a constructed instance |
| `POST_LOAD_SURFACE` | 3 | Declared; `dataset.isLive` asserted |
| `SUB_SURFACES` | 6 | Presence on their owner |
| `COORDINATOR_CALLBACKS` | 6 | Exercised — registers each, asserts unknown throws |
| `EVENTS_POSTED` | 7 | Bus reachability only — see the gap below |

The check runs **one way**: declared members must exist. New undeclared members do
not fail the build — the reverse check would mean classifying ~68 prototype members
up front, and is deliberately deferred.

## Three things verification changed

Worth reviewing closely, because all three departed from the plan in #470.

**1. Spacewalk reads `contactMatrixView.viewportElement`** (`liveMapView.js:53`),
which ADR-0003's hand-built table missed — so the manifest inherited the gap until
code review caught it. It is now declared and asserted, and recorded in the ADR. This
is the same failure mode as `MapLoad`, found one week after the table was measured,
and is the argument for this PR in one data point.

**2. The JSDoc-docblock approach the plan specified does not work.** `test/setup.js`
installs a hand-rolled `document` mock globally for all test files, which would
clobber JSDOM's. The fixture stands up its own JSDOM and swaps globals for the
duration instead, leaving the existing 17 test files and their mock untouched. The
canvas obstacle was also real — `ContactMatrixView`, the ruler and the track renderer
all call `getContext('2d')` in their constructors, so the 2D context is stubbed inert
rather than pulling in the native `canvas` package.

**3. `dataset.isLive` is asserted, not just declared** as the plan assumed — a
`HiCDataset` turns out to construct standalone, so the stronger check was available.

## The known gap

**Declared events are not enforced.** The test asserts that each declared bus is real
and subscribable, not that juicebox still *posts* each event. Nothing here would catch
a repeat of the `MapLoad` regression. Proving an event still fires means driving a real
map load and watching the bus, which needs the probe harness of #438 — that makes #438
less optional than it currently reads. `js/publicApi.js` says this in the source rather
than burying it.

A source-text scan for `HICEvent("...")` literals was considered and rejected as
testing source rather than behaviour.

## Also in this branch

- **Two corrections to ADR-0003**, both found by checking it against the code: the
  dataset flag is `isLive`, not `isLiveContactMapDataSet` (a name in no repo), and the
  coordinator accepts six callback names, not three. Neither changes its conclusion;
  both are the drift it predicts, in a document written the same week.
- **ADR-0003 marked superseded in part**, per its own reversal clause. It keeps the
  reasoning and consumer-usage evidence; the manifest owns the surface.
- **`CONTEXT.md`** gains *public surface*, *manifest*, *dataset* and *the disguise* —
  the last two naming the live contact map seam, which nothing documented.
- **Architecture review candidate 10 retitled** to say it *is* the live-map seam, with
  a note on what scoping it actually involves.
- **#471 filed** — `onMapLoaded`'s `datasetType` is documented as `"main"`/`"control"`
  but is always `'live' | 'hic' | 'unknown'`. Found via this work; a case where the
  manifest declares the name correctly and the *meaning* is wrong, which is a real
  limit of the approach.

## Verification

- `npm test` — 18 files, 313 tests, green
- `npm run build` — clean; confirmed the manifest is tree-shaken out of
  `dist/juicebox.min.js` (nothing imports it at runtime)
- Reviewed on both axes via `/code-review`; findings that held up on verification are
  fixed in the final commit, including one false claim in my own module header
  (`package.json` `files` is `dist` and `dev-proxy` only, so the manifest does not ship
  in the package — it is repo source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
