### PR TITLE
Introduce BrowserRegistry holding today's module state (#478)

### DIFF
--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -1,0 +1,130 @@
+import EventBus from './eventBus.js'
+import HICEvent from './hicEvent.js'
+import {pairSynchable} from './syncGroup.js'
+
+/**
+ * The owner of one embed's browsers: the list, which of them is current, and
+ * their sync group. See `CONTEXT.md` and `docs/adr/0004-browser-registry-per-container.md`.
+ *
+ * A registry never constructs a browser -- `js/createBrowser.js` does that and
+ * hands the result over. The registry reads only four things off a browser:
+ * `rootElement`, `browserPanelDeleteButton`, `synchedBrowsers` and
+ * `unsyncSelf()`. That is what makes it constructible in a test.
+ *
+ * There is still exactly one registry per page (#478 is the lift; keying
+ * registries by container element is decisions 2 and 8 of the ADR, and lands
+ * separately), so nothing here is yet reachable twice on one page.
+ *
+ * Two things the ADR calls for are deliberately absent, because #478 is a lift
+ * and may not change observable behaviour:
+ *
+ * - selection does not fall through on delete, so `currentBrowser` can still
+ *   name a browser that has left the DOM. That is #475, ADR decision 7.
+ * - the sync group is still each browser's own `synchedBrowsers` set. What the
+ *   registry owns is the *membership rule*: whose browsers get paired.
+ */
+class BrowserRegistry {
+
+    constructor() {
+        this.browsers = []
+        this.currentBrowser = undefined
+    }
+
+    /**
+     * Take ownership of a browser, without selecting it.
+     *
+     * The session path registers each browser *before* initializing it,
+     * because loading a dataset consults the registry (`HICBrowser.unsyncSelf`,
+     * `dataLoader`). Its delete button does not exist yet, so visibility is not
+     * settled here; that path calls `refreshDeleteButtonVisibility` once
+     * initialization has finished.
+     */
+    register(browser) {
+        this.browsers.push(browser)
+    }
+
+    /**
+     * Take ownership of a fully initialized browser and select it.
+     */
+    add(browser) {
+        this.register(browser)
+        this.select(browser)
+        this.refreshDeleteButtonVisibility()
+    }
+
+    /**
+     * Give up the browsers without tearing them down -- the opposite of
+     * `deleteAll`, which removes their DOM. The session path clears before
+     * rebuilding, its previous browsers having already been deleted.
+     */
+    clear() {
+        this.browsers = []
+    }
+
+    /**
+     * Make `browser` the current one, or clear the selection when given
+     * `undefined`. Posts `BrowserSelect` only on a real transition to a
+     * browser, which is the contract juicebox-web subscribes to.
+     */
+    select(browser) {
+
+        if (browser === undefined) {
+            this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
+            this.currentBrowser = undefined
+            return
+        }
+
+        if (browser !== this.currentBrowser) {
+            this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
+            browser.rootElement.classList.add('hic-root-selected')
+            this.currentBrowser = browser
+            EventBus.globalBus.post(HICEvent("BrowserSelect", browser))
+        }
+    }
+
+    delete(browser) {
+        browser.unsyncSelf()
+        browser.rootElement.remove()
+        this.browsers = this.browsers.filter(b => b !== browser)
+        this.refreshDeleteButtonVisibility()
+    }
+
+    deleteAll() {
+        for (const browser of this.browsers) {
+            browser.rootElement.remove()
+        }
+        this.clear()
+    }
+
+    async updateAll() {
+        for (const browser of this.browsers) {
+            await browser.update()
+        }
+    }
+
+    /**
+     * Join the compatible browsers into each other's sync group. Defaults to
+     * this registry's browsers; an explicit list is how a caller syncs a subset
+     * (and, per decision 6 of the ADR, how a cross-registry group would later
+     * be expressed).
+     */
+    sync(browsers) {
+        for (const [b1, b2] of pairSynchable(browsers || this.browsers)) {
+            b1.synchedBrowsers.add(b2)
+            b2.synchedBrowsers.add(b1)
+        }
+    }
+
+    /**
+     * A browser can only be deleted while it has a sibling, so the button is
+     * visible exactly when the registry holds more than one browser.
+     */
+    refreshDeleteButtonVisibility() {
+        const display = this.browsers.length > 1 ? 'block' : 'none'
+        for (const browser of this.browsers) {
+            browser.browserPanelDeleteButton.style.display = display
+        }
+    }
+}
+
+export default BrowserRegistry

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -4,119 +4,102 @@
 
 import { StringUtils } from 'igv-utils';
 import HICBrowser from './hicBrowser.js';
+import BrowserRegistry from './browserRegistry.js';
 import {parseColorScale} from './colorScaleParser.js';
 import ContactMatrixView from "./contactMatrixView.js";
-import HICEvent from "./hicEvent.js";
-import EventBus from "./eventBus.js";
-import {pairSynchable} from "./syncGroup.js";
 
 const defaultSize = { width: 640, height: 640 };
 
-let allBrowsers = [];
-let currentBrowser;
+/**
+ * The page's one registry. Every export below is a convenience over it, kept
+ * and delegating per decision 4 of ADR-0004 -- both known host apps import
+ * them, as ADR-0003 measures.
+ *
+ * Resolving a registry from the container element instead -- so two embeds can
+ * coexist -- is decisions 2 and 8 of `docs/adr/0004-browser-registry-per-container.md`
+ * and lands separately. Until then this constant is the whole population.
+ */
+const defaultRegistry = new BrowserRegistry();
 
 async function createBrowser(hicContainer, config, callback) {
-    setDefaults(config);
 
-    if (StringUtils.isString(config.colorScale)) config.colorScale = parseColorScale(config.colorScale);
-    if (StringUtils.isString(config.backgroundColor)) config.backgroundColor = ContactMatrixView.parseBackgroundColor(config.backgroundColor);
+    normalizeConfig(config);
 
     const browser = new HICBrowser(hicContainer, config);
     await browser.init(config);
 
     if (typeof callback === "function") callback();
 
-    allBrowsers.push(browser);
-    setCurrentBrowser(browser);
-
-    if (allBrowsers.length > 1) {
-        allBrowsers.forEach(b => b.browserPanelDeleteButton.style.display = 'block');
-    }
+    defaultRegistry.add(browser);
 
     return browser;
 }
 
 async function createBrowserList(hicContainer, session) {
+
     const configList = session.browsers || [session];
-    allBrowsers = [];
     const initPromises = [];
+
+    defaultRegistry.clear();
 
     for (const config of configList) {
 
-        setDefaults(config)
+        normalizeConfig(config);
 
-        if (StringUtils.isString(config.colorScale)) {
-            config.colorScale = parseColorScale(config.colorScale);
-        }
-        if (StringUtils.isString(config.backgroundColor)) {
-            config.backgroundColor = ContactMatrixView.parseBackgroundColor(config.backgroundColor);
-        }
         if (session.syncDatasets === false) {
             config.synchable = false;
         }
 
         const browser = new HICBrowser(hicContainer, config);
-        allBrowsers.push(browser);
+
+        // Registered before init: loading a dataset consults the registry.
+        defaultRegistry.register(browser);
         initPromises.push(browser.init(config));
     }
     await Promise.all(initPromises);
-    setCurrentBrowser(allBrowsers[0]);
 
-    if (allBrowsers.length > 1) {
-        allBrowsers.forEach(b => b.browserPanelDeleteButton.style.display = 'block');
-    }
+    defaultRegistry.select(defaultRegistry.browsers[0]);
+    defaultRegistry.refreshDeleteButtonVisibility();
 }
 
 async function updateAllBrowsers() {
-    for (let b of allBrowsers) {
-        await b.update();
-    }
+    await defaultRegistry.updateAll();
 }
 
 function deleteAllBrowsers() {
-    for (let b of allBrowsers) {
-        b.rootElement.remove();
-    }
-    allBrowsers = [];
+    defaultRegistry.deleteAll();
 }
 
 function setCurrentBrowser(browser) {
-    if (browser === undefined) {
-        currentBrowser?.rootElement.classList.remove('hic-root-selected');
-        currentBrowser = browser;
-        return;
-    }
-
-    if (browser !== currentBrowser) {
-        currentBrowser?.rootElement.classList.remove('hic-root-selected');
-        browser.rootElement.classList.add('hic-root-selected');
-        currentBrowser = browser;
-        EventBus.globalBus.post(HICEvent("BrowserSelect", browser));
-    }
+    defaultRegistry.select(browser);
 }
 
 function deleteBrowser(browser) {
-    browser.unsyncSelf();
-    browser.rootElement.remove();
-    allBrowsers = allBrowsers.filter(b => b !== browser);
-    if (allBrowsers.length <= 1) {
-        allBrowsers.forEach(b => b.browserPanelDeleteButton.style.display = 'none');
-    }
+    defaultRegistry.delete(browser);
 }
 
 function getCurrentBrowser() {
-    return currentBrowser;
+    return defaultRegistry.currentBrowser;
 }
 
 function syncBrowsers(browsers) {
-    for (const [ b1, b2 ] of pairSynchable(browsers || allBrowsers)) {
-        b1.synchedBrowsers.add(b2);
-        b2.synchedBrowsers.add(b1);
-    }
+    defaultRegistry.sync(browsers);
 }
 
 function getAllBrowsers() {
-    return allBrowsers;
+    return defaultRegistry.browsers;
+}
+
+function normalizeConfig(config) {
+
+    setDefaults(config);
+
+    if (StringUtils.isString(config.colorScale)) {
+        config.colorScale = parseColorScale(config.colorScale);
+    }
+    if (StringUtils.isString(config.backgroundColor)) {
+        config.backgroundColor = ContactMatrixView.parseBackgroundColor(config.backgroundColor);
+    }
 }
 
 function setDefaults(config) {

--- a/test/testBrowserRegistry.js
+++ b/test/testBrowserRegistry.js
@@ -1,0 +1,298 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import BrowserRegistry from '../js/browserRegistry.js'
+import EventBus from '../js/eventBus.js'
+
+/**
+ * The browser registry -- see #478, decision 1 of ADR-0004.
+ *
+ * The registry owns the browser list, the current-browser pointer and the sync
+ * group. It never constructs a browser, so the browsers here are fabricated
+ * objects carrying only what the registry reads: the two DOM handles it
+ * touches, the sync members, and `unsyncSelf`.
+ */
+
+function fakeElement() {
+    const classes = new Set()
+    return {
+        removed: false,
+        classList: {
+            add: name => classes.add(name),
+            remove: name => classes.delete(name),
+            contains: name => classes.has(name)
+        },
+        remove() {
+            this.removed = true
+        }
+    }
+}
+
+function fakeBrowser(name, {dataset, synchable} = {}) {
+    const browser = {
+        name,
+        rootElement: fakeElement(),
+        browserPanelDeleteButton: {style: {display: 'none'}},
+        synchedBrowsers: new Set(),
+        unsyncSelfCalls: 0,
+        unsyncSelf() {
+            this.unsyncSelfCalls++
+        }
+    }
+    if (dataset !== undefined) browser.dataset = dataset
+    if (synchable !== undefined) browser.synchable = synchable
+    return browser
+}
+
+function fakeDataset(genomeId) {
+    return {
+        genomeId,
+        isCompatible: other => other.genomeId === genomeId
+    }
+}
+
+function isSelected(browser) {
+    return browser.rootElement.classList.contains('hic-root-selected')
+}
+
+function deleteButtonDisplays(registry) {
+    return registry.browsers.map(b => b.browserPanelDeleteButton.style.display)
+}
+
+describe('BrowserRegistry', () => {
+
+    let registry
+    let selectEvents
+    let selectListener
+
+    beforeEach(() => {
+        registry = new BrowserRegistry()
+        selectEvents = []
+        selectListener = event => selectEvents.push(event)
+        EventBus.globalBus.subscribe('BrowserSelect', selectListener)
+    })
+
+    afterEach(() => {
+        EventBus.globalBus.unsubscribe('BrowserSelect', selectListener)
+    })
+
+    describe('add', () => {
+
+        it('holds the added browser and makes it current', () => {
+            const a = fakeBrowser('a')
+
+            registry.add(a)
+
+            expect(registry.browsers).toEqual([a])
+            expect(registry.currentBrowser).toBe(a)
+            expect(isSelected(a)).toBe(true)
+        })
+
+        it('leaves the delete button hidden while there is one browser', () => {
+            registry.add(fakeBrowser('a'))
+
+            expect(deleteButtonDisplays(registry)).toEqual(['none'])
+        })
+
+        it('shows every delete button once a second browser arrives', () => {
+            registry.add(fakeBrowser('a'))
+            registry.add(fakeBrowser('b'))
+
+            expect(deleteButtonDisplays(registry)).toEqual(['block', 'block'])
+        })
+    })
+
+    describe('register', () => {
+
+        it('takes the browser without selecting it', () => {
+            const a = fakeBrowser('a')
+
+            registry.register(a)
+
+            expect(registry.browsers).toEqual([a])
+            expect(registry.currentBrowser).toBeUndefined()
+            expect(isSelected(a)).toBe(false)
+            expect(selectEvents).toHaveLength(0)
+        })
+
+        it('leaves delete-button visibility alone, the button not existing yet', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            b.browserPanelDeleteButton = undefined
+
+            registry.register(a)
+
+            expect(() => registry.register(b)).not.toThrow()
+            expect(a.browserPanelDeleteButton.style.display).toBe('none')
+        })
+    })
+
+    describe('clear', () => {
+
+        it('gives up the browsers without touching their DOM', () => {
+            const a = fakeBrowser('a')
+            registry.add(a)
+
+            registry.clear()
+
+            expect(registry.browsers).toEqual([])
+            expect(a.rootElement.removed).toBe(false)
+        })
+    })
+
+    describe('select', () => {
+
+        it('posts BrowserSelect and moves the selected class', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            for (const browser of [a, b]) registry.register(browser)
+
+            registry.select(a)
+            registry.select(b)
+
+            expect(registry.currentBrowser).toBe(b)
+            expect(isSelected(a)).toBe(false)
+            expect(isSelected(b)).toBe(true)
+            expect(selectEvents.map(e => e.data)).toEqual([a, b])
+        })
+
+        it('does not post when the browser is already current', () => {
+            const a = fakeBrowser('a')
+            for (const browser of [a]) registry.register(browser)
+
+            registry.select(a)
+            registry.select(a)
+
+            expect(selectEvents).toHaveLength(1)
+        })
+
+        it('clears the selection without posting when given undefined', () => {
+            const a = fakeBrowser('a')
+            registry.add(a)
+            selectEvents.length = 0
+
+            registry.select(undefined)
+
+            expect(registry.currentBrowser).toBeUndefined()
+            expect(isSelected(a)).toBe(false)
+            expect(selectEvents).toHaveLength(0)
+        })
+    })
+
+    describe('delete', () => {
+
+        it('removes the browser from the list and from the DOM', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+
+            registry.delete(a)
+
+            expect(registry.browsers).toEqual([b])
+            expect(a.rootElement.removed).toBe(true)
+            expect(a.unsyncSelfCalls).toBe(1)
+        })
+
+        it('hides the delete buttons once one browser is left', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+
+            registry.delete(a)
+
+            expect(deleteButtonDisplays(registry)).toEqual(['none'])
+        })
+
+        it('keeps the delete buttons visible while two browsers remain', () => {
+            const [a, b, c] = ['a', 'b', 'c'].map(name => fakeBrowser(name))
+            for (const browser of [a, b, c]) registry.add(browser)
+
+            registry.delete(c)
+
+            expect(deleteButtonDisplays(registry)).toEqual(['block', 'block'])
+        })
+
+        it('leaves the deleted browser current -- selection fall-through is #475, not this lift', () => {
+            const a = fakeBrowser('a')
+            registry.add(a)
+
+            registry.delete(a)
+
+            expect(registry.currentBrowser).toBe(a)
+        })
+    })
+
+    describe('deleteAll', () => {
+
+        it('empties the list and removes every root element', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+
+            registry.deleteAll()
+
+            expect(registry.browsers).toEqual([])
+            expect(a.rootElement.removed).toBe(true)
+            expect(b.rootElement.removed).toBe(true)
+        })
+    })
+
+    describe('sync', () => {
+
+        it('joins the registry\'s compatible browsers into each other\'s sync group', () => {
+            const hg38 = fakeDataset('hg38')
+            const a = fakeBrowser('a', {dataset: hg38})
+            const b = fakeBrowser('b', {dataset: hg38})
+            const other = fakeBrowser('other', {dataset: fakeDataset('hg19')})
+            for (const browser of [a, b, other]) registry.register(browser)
+
+            registry.sync()
+
+            expect([...a.synchedBrowsers]).toEqual([b])
+            expect([...b.synchedBrowsers]).toEqual([a])
+            expect([...other.synchedBrowsers]).toEqual([])
+        })
+
+        it('syncs an explicit list instead of the registry when given one', () => {
+            const hg38 = fakeDataset('hg38')
+            const a = fakeBrowser('a', {dataset: hg38})
+            const b = fakeBrowser('b', {dataset: hg38})
+            for (const browser of [a]) registry.register(browser)
+
+            registry.sync([a, b])
+
+            expect([...a.synchedBrowsers]).toEqual([b])
+            expect([...b.synchedBrowsers]).toEqual([a])
+        })
+    })
+
+    describe('updateAll', () => {
+
+        it('awaits an update on every browser', async () => {
+            const updated = []
+            const browsers = ['a', 'b'].map(name => {
+                const browser = fakeBrowser(name)
+                browser.update = async () => updated.push(name)
+                return browser
+            })
+            for (const browser of browsers) registry.register(browser)
+
+            await registry.updateAll()
+
+            expect(updated).toEqual(['a', 'b'])
+        })
+    })
+
+    describe('isolation', () => {
+
+        it('does not share browsers with another registry', () => {
+            const other = new BrowserRegistry()
+
+            registry.add(fakeBrowser('a'))
+
+            expect(other.browsers).toEqual([])
+            expect(other.currentBrowser).toBeUndefined()
+        })
+    })
+})


### PR DESCRIPTION
Closes #478.

The set of live browsers gets an owner object instead of a module-level `let`. `BrowserRegistry` (`js/browserRegistry.js`) holds the browser list, the current-browser pointer and the sync-group membership rule; `js/createBrowser.js` keeps all nine exports and delegates to one default instance, per decision 4 of [ADR-0004](../blob/master/docs/adr/0004-browser-registry-per-container.md).

The registry never constructs a browser and reads only four members off one — `rootElement`, `browserPanelDeleteButton`, `synchedBrowsers`, `unsyncSelf()` — so it imports no `HICBrowser` and is constructible in a `node`-environment test. That is the point of the ticket: somewhere for the next one to put a second registry.

## A pure lift

One registry per page still, so nothing observable changes for the dev harness or either host app. Three places where that took care:

- **Delete-button visibility** becomes one rule (`browsers.length > 1`) instead of two partial ones. Identical along every reachable path, because `layoutController.js:298` sets `'none'` at construction.
- **`createBrowserList` keeps HEAD's exact interleaving** — clear, then construct / register / start-init per config. Batching the constructors first would have deferred the first browser's spinner and network request behind construction of every remaining panel. `register` (push only) and `add` (push + select + refresh) are separate for this reason.
- **`BrowserSelect`** posts on the same transitions, and only on a real transition to a browser.

Also folded the config normalization duplicated across the two entry points into one `normalizeConfig`.

## Deliberately out of scope

Both pinned in the class doc, and the first in a test so it cannot regress silently:

- Selection does not fall through on delete, so `currentBrowser` can still name a browser that has left the DOM — #475, ADR decision 7.
- Registries are not yet keyed by container element (ADR decisions 2 and 8). #478's Parent line has been corrected to cite decision 1 only.

## Testing

`test/testBrowserRegistry.js` — 18 tests over add / register / select / delete / deleteAll / sync / updateAll against browser-shaped test doubles, styled after `test/testSyncGroup.js`.

Full suite green: 363 tests across 24 files. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)