### PR TITLE
Key browser registries by container element (#479)

### DIFF
--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -11,12 +11,11 @@ import {pairSynchable} from './syncGroup.js'
  * `rootElement`, `browserPanelDeleteButton`, `synchedBrowsers` and
  * `unsyncSelf()`. That is what makes it constructible in a test.
  *
- * There is still exactly one registry per page (#478 is the lift; keying
- * registries by container element is decisions 2 and 8 of the ADR, and lands
- * separately), so nothing here is yet reachable twice on one page.
+ * One registry owns one container element; `registryForContainer` below is how
+ * every entry point finds the right one.
  *
- * Two things the ADR calls for are deliberately absent, because #478 is a lift
- * and may not change observable behaviour:
+ * Two things the ADR calls for are deliberately absent, because #478 was a lift
+ * and #479 a re-keying, and neither may change observable behaviour:
  *
  * - selection does not fall through on delete, so `currentBrowser` can still
  *   name a browser that has left the DOM. That is #475, ADR decision 7.
@@ -69,10 +68,17 @@ class BrowserRegistry {
     select(browser) {
 
         if (browser === undefined) {
+            if (mostRecentlySelectedBrowser === this.currentBrowser) {
+                mostRecentlySelectedBrowser = undefined
+            }
             this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
             this.currentBrowser = undefined
             return
         }
+
+        // Outside the transition check below: a browser already current in its
+        // own registry is not necessarily the last one selected page-wide.
+        mostRecentlySelectedBrowser = browser
 
         if (browser !== this.currentBrowser) {
             this.currentBrowser?.rootElement.classList.remove('hic-root-selected')
@@ -127,4 +133,50 @@ class BrowserRegistry {
     }
 }
 
+/**
+ * Every registry on the page, keyed by the container element it owns.
+ *
+ * A `WeakMap` rather than a property on the container, per decision 8 of the
+ * ADR: the host owns that element, and juicebox writes nothing onto it. The
+ * weak key also means a host that drops its container drops the registry with
+ * it, without juicebox having to be told.
+ */
+const registriesByContainer = new WeakMap()
+
+/**
+ * The browser most recently handed to any registry's `select`, page-wide.
+ *
+ * This is what the old module-level `currentBrowser` in `createBrowser.js`
+ * always was -- "whoever `setCurrentBrowser` last received, from anywhere" --
+ * and keeping it byte-for-byte is what lets `getCurrentBrowser()` survive the
+ * move to per-container registries unchanged. See decision 4.
+ */
+let mostRecentlySelectedBrowser
+
+/**
+ * The registry owning `container`, created on first ask.
+ *
+ * Every entry point into juicebox resolves its registry through here, so
+ * calling in twice with the same element finds the same registry -- which is
+ * what makes a second `init()` on one container replace its contents rather
+ * than open a rival embed. A different element gets a different registry, which
+ * is #384. Decision 2.
+ */
+function registryForContainer(container) {
+
+    let registry = registriesByContainer.get(container)
+
+    if (undefined === registry) {
+        registry = new BrowserRegistry()
+        registriesByContainer.set(container, registry)
+    }
+
+    return registry
+}
+
+function getMostRecentlySelectedBrowser() {
+    return mostRecentlySelectedBrowser
+}
+
 export default BrowserRegistry
+export {registryForContainer, getMostRecentlySelectedBrowser}

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -4,22 +4,23 @@
 
 import { StringUtils } from 'igv-utils';
 import HICBrowser from './hicBrowser.js';
-import BrowserRegistry from './browserRegistry.js';
+import {registryForContainer, getMostRecentlySelectedBrowser} from './browserRegistry.js';
 import {parseColorScale} from './colorScaleParser.js';
 import ContactMatrixView from "./contactMatrixView.js";
 
 const defaultSize = { width: 640, height: 640 };
 
 /**
- * The page's one registry. Every export below is a convenience over it, kept
- * and delegating per decision 4 of ADR-0004 -- both known host apps import
- * them, as ADR-0003 measures.
+ * Module-level conveniences over the registries, kept and delegating per
+ * decision 4 of ADR-0004 -- both known host apps import them, as ADR-0003
+ * measures.
  *
- * Resolving a registry from the container element instead -- so two embeds can
- * coexist -- is decisions 2 and 8 of `docs/adr/0004-browser-registry-per-container.md`
- * and lands separately. Until then this constant is the whole population.
+ * There is no default registry: each function below resolves one, from its
+ * container argument, from `browser.registry`, or -- for the two zero-argument
+ * getters, which have nothing to resolve from -- from the browser most recently
+ * selected page-wide. See `js/browserRegistry.js` and decisions 2, 8 and 9 of
+ * `docs/adr/0004-browser-registry-per-container.md`.
  */
-const defaultRegistry = new BrowserRegistry();
 
 async function createBrowser(hicContainer, config, callback) {
 
@@ -30,17 +31,18 @@ async function createBrowser(hicContainer, config, callback) {
 
     if (typeof callback === "function") callback();
 
-    defaultRegistry.add(browser);
+    registryForContainer(hicContainer).add(browser);
 
     return browser;
 }
 
 async function createBrowserList(hicContainer, session) {
 
+    const registry = registryForContainer(hicContainer);
     const configList = session.browsers || [session];
     const initPromises = [];
 
-    defaultRegistry.clear();
+    registry.clear();
 
     for (const config of configList) {
 
@@ -53,41 +55,69 @@ async function createBrowserList(hicContainer, session) {
         const browser = new HICBrowser(hicContainer, config);
 
         // Registered before init: loading a dataset consults the registry.
-        defaultRegistry.register(browser);
+        registry.register(browser);
         initPromises.push(browser.init(config));
     }
     await Promise.all(initPromises);
 
-    defaultRegistry.select(defaultRegistry.browsers[0]);
-    defaultRegistry.refreshDeleteButtonVisibility();
+    registry.select(registry.browsers[0]);
+    registry.refreshDeleteButtonVisibility();
 }
 
-async function updateAllBrowsers() {
-    await defaultRegistry.updateAll();
+function deleteAllBrowsers(hicContainer) {
+    registryForContainer(hicContainer).deleteAll();
 }
 
-function deleteAllBrowsers() {
-    defaultRegistry.deleteAll();
-}
-
+/**
+ * Select `browser` in its own registry, or -- given `undefined` -- clear the
+ * selection of whichever registry currently holds it.
+ *
+ * The `undefined` case is the one call that has no back-pointer to resolve
+ * through, and it predates the registries: `select` has always accepted it. So
+ * it falls back to the page-wide pointer, which in the single-embed case names
+ * the same registry a browser argument would have.
+ */
 function setCurrentBrowser(browser) {
-    defaultRegistry.select(browser);
+
+    if (undefined === browser) {
+        getMostRecentlySelectedBrowser()?.registry.select(undefined);
+        return;
+    }
+
+    browser.registry.select(browser);
 }
 
 function deleteBrowser(browser) {
-    defaultRegistry.delete(browser);
+    browser.registry.delete(browser);
 }
 
+/**
+ * The browser most recently selected, anywhere on the page.
+ *
+ * A single-embed convenience: with two embeds it names whichever one the user
+ * touched last, which is rarely what a caller holding a particular container
+ * means. Multi-embed callers should reach the registry -- `browser.registry`,
+ * or `registryForContainer(container)` -- instead of asking page-wide.
+ */
 function getCurrentBrowser() {
-    return defaultRegistry.currentBrowser;
+    return getMostRecentlySelectedBrowser();
 }
 
-function syncBrowsers(browsers) {
-    defaultRegistry.sync(browsers);
-}
-
+/**
+ * The browsers of the registry owning the current browser, and `[]` before
+ * anything has been selected.
+ *
+ * The same single-embed convenience as `getCurrentBrowser`, and inherits its
+ * caveat: which embed's list this is follows the page-wide selection. A
+ * multi-embed caller wants `registryForContainer(container).browsers`.
+ *
+ * The empty case is reachable mid-initialization as well as before it:
+ * `createBrowserList` registers every browser and only selects once they have
+ * all initialized, so a caller reading this from inside a load sees `[]`. That
+ * is the other reason to hold a registry rather than ask page-wide.
+ */
 function getAllBrowsers() {
-    return defaultRegistry.browsers;
+    return getMostRecentlySelectedBrowser()?.registry.browsers || [];
 }
 
 function normalizeConfig(config) {
@@ -124,7 +154,6 @@ export {
     deleteBrowser,
     setCurrentBrowser,
     getCurrentBrowser,
-    syncBrowsers,
     deleteAllBrowsers,
     getAllBrowsers
 };

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -28,7 +28,6 @@ import State from './hicState.js'
 import Genome from './genome.js'
 import {extractName, presentError, isBotChallenge} from "./utils.js"
 import {isFile} from "./fileUtils.js"
-import {getAllBrowsers, syncBrowsers} from "./createBrowser.js"
 import HICEvent from './hicEvent.js'
 import EventBus from './eventBus.js'
 import nvi from './nvi.js'
@@ -164,10 +163,14 @@ class DataLoader {
                     });
             }
 
-            syncBrowsers(); // Sync browsers to ensure all browsers are updated with the new dataset
+            // This browser's own registry: syncing is scoped to one embed, so a
+            // dataset arriving here never reaches across to another container.
+            const registry = this.browser.registry;
+
+            registry.sync(); // Sync browsers to ensure all browsers are updated with the new dataset
 
             // Find a browser to sync with, if any
-            const compatibleBrowsers = getAllBrowsers().filter(
+            const compatibleBrowsers = registry.browsers.filter(
                 b => b !== this.browser &&
                      b.dataset &&
                      b.dataset.isCompatible(this.browser.dataset)

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -31,7 +31,7 @@ import {Globals} from "./globals.js"
 import EventBus from "./eventBus.js"
 import LayoutController, {setViewportSize} from './layoutController.js'
 import { geneSearch } from './geneSearch.js'
-import {getAllBrowsers} from "./createBrowser.js"
+import {registryForContainer} from "./browserRegistry.js"
 import {setTrackReorderArrowColors} from "./trackPair.js"
 import createWidgets from "./createWidgets.js"
 import BrowserCoordinator from "./browserCoordinator.js"
@@ -46,6 +46,14 @@ const MAX_PIXEL_SIZE = 128
 class HICBrowser {
 
     constructor(appContainer, config) {
+
+        // The back-pointer, per decision 9 of ADR-0004: `setCurrentBrowser` and
+        // `deleteBrowser` are handed a browser and nothing else, so this is how
+        // they find the registry to act on. Set here rather than by whoever
+        // registers the browser, so it holds for a browser's whole life --
+        // including during `init()`, which loads a dataset and so consults it.
+        this.registry = registryForContainer(appContainer);
+
         this.config = config;
         this.figureMode = config.figureMode || config.miniMode; // Mini mode for backward compatibility
         this.resolutionLocked = false;
@@ -515,8 +523,7 @@ class HICBrowser {
      * Remove reference to self from all synchedBrowsers lists.
      */
     unsyncSelf() {
-        const allBrowsers = getAllBrowsers()
-        for (let b of allBrowsers) {
+        for (let b of this.registry.browsers) {
             b.unsync(this)
         }
     }

--- a/js/init.js
+++ b/js/init.js
@@ -22,8 +22,7 @@
  */
 
 import {extractConfig} from "./urlUtils.js"
-import {getCurrentBrowser} from "./createBrowser.js"
-import {getAllBrowsers} from "./createBrowser.js"
+import {registryForContainer} from "./browserRegistry.js"
 import {restoreSession} from "./session.js"
 import {Alert} from "igv-ui"
 
@@ -40,7 +39,9 @@ async function init(container, config) {
 
     await restoreSession(container, config);
 
-    const allBrowsers = getAllBrowsers();
+    // This container's browsers, not the page's: `init()` must return what it
+    // just built even when another embed has since been selected.
+    const allBrowsers = registryForContainer(container).browsers;
 
     return allBrowsers.length === 1 ? allBrowsers[0] : allBrowsers
 }

--- a/js/publicApi.js
+++ b/js/publicApi.js
@@ -123,6 +123,12 @@ export const BROWSER_SURFACE = [
     // Constructor-assigned fields
     'id',
     'config',
+    // The registry owning this browser's embed. Declared deliberately rather
+    // than acquired by accident: `setCurrentBrowser(browser)` resolves through
+    // it, so it is load-bearing from the moment it ships, and it is the route a
+    // multi-embed host takes when the page-wide getters are the wrong question.
+    // Decision 9 of ADR-0004, #479.
+    'registry',
     'rootElement',
     'eventBus',
     'coordinator',

--- a/js/session.js
+++ b/js/session.js
@@ -1,4 +1,5 @@
-import {createBrowserList, deleteAllBrowsers, getAllBrowsers, syncBrowsers} from "./createBrowser.js"
+import {createBrowserList, deleteAllBrowsers, getAllBrowsers} from "./createBrowser.js"
+import {registryForContainer} from "./browserRegistry.js"
 import {Globals} from "./globals.js"
 import {StringUtils, BGZip} from "igv-utils";
 import {expandUrlShortcuts} from "./urlUtils.js";
@@ -6,6 +7,11 @@ import {expandUrlShortcuts} from "./urlUtils.js";
 function toJSON() {
     const jsonOBJ = {};
     const browserJson = [];
+
+    // Page-wide, because `toJSON()` is a published zero-argument export with no
+    // container to resolve from. Serializing one embed's session rather than
+    // "whichever embed was touched last" is decision 5 of ADR-0004, which needs
+    // `registry.toJSON()` and lands with the per-embed session work.
     const allBrowsers = getAllBrowsers();
     for (let browser of allBrowsers) {
         browserJson.push(browser.toJSON());
@@ -38,7 +44,7 @@ function compressedSession() {
 
 async function restoreSession(container, session) {
 
-    deleteAllBrowsers();
+    deleteAllBrowsers(container);
 
     // Expand URL shortcuts in session config for backward compatibility
     // This ensures sessions passed directly to restoreSession (not through extractConfig)
@@ -90,7 +96,7 @@ async function restoreSession(container, session) {
     await createBrowserList(container, session);
 
     if (false !== session.syncDatasets) {
-        syncBrowsers();
+        registryForContainer(container).sync();
     }
 
 }

--- a/test/testRegistryLookup.js
+++ b/test/testRegistryLookup.js
@@ -1,0 +1,271 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import BrowserRegistry, {registryForContainer} from '../js/browserRegistry.js'
+import {getAllBrowsers, getCurrentBrowser, setCurrentBrowser} from '../js/createBrowser.js'
+import HICBrowser from '../js/hicBrowser.js'
+import {withDOM} from './utils/browserFixture.js'
+
+/**
+ * Finding a registry by its container element -- #479, decisions 2, 4, 8 and 9
+ * of ADR-0004.
+ *
+ * These are the tests for the step the ADR calls the riskiest: keying registries
+ * by container while the module-level functions keep delegating. A mistake there
+ * changes what a host's `getAllBrowsers()` returns with nothing failing, so what
+ * is asserted here is precisely the resolution policy -- which registry each
+ * entry point lands on -- rather than anything about browsers themselves.
+ *
+ * Real elements, not plain objects: one of the promises being kept is that
+ * juicebox writes nothing onto an element the host owns, and only a real element
+ * can be inspected for that.
+ */
+
+/**
+ * A JSDOM around each test in the calling describe, exposing the container the
+ * fixture makes and a way to make more of them. Returns a holder rather than
+ * the elements, which do not exist until `beforeEach` runs.
+ */
+function withContainers() {
+
+    const context = {}
+    let fixture
+
+    beforeEach(() => {
+        fixture = withDOM()
+        context.window = fixture.window
+        context.container = fixture.container
+        context.another = () => {
+            const element = fixture.window.document.createElement('div')
+            fixture.window.document.body.appendChild(element)
+            return element
+        }
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    return context
+}
+
+function fakeBrowser(name, registry) {
+    const classes = new Set()
+    return {
+        name,
+        registry,
+        rootElement: {
+            classList: {
+                add: item => classes.add(item),
+                remove: item => classes.delete(item)
+            },
+            remove: () => {
+            }
+        },
+        browserPanelDeleteButton: {style: {display: 'none'}},
+        synchedBrowsers: new Set(),
+        unsyncSelf: () => {
+        }
+    }
+}
+
+describe('registryForContainer', () => {
+
+    const dom = withContainers()
+
+    it('hands back the same registry for the same container', () => {
+        expect(registryForContainer(dom.container)).toBe(registryForContainer(dom.container))
+    })
+
+    it('hands back a registry', () => {
+        expect(registryForContainer(dom.container)).toBeInstanceOf(BrowserRegistry)
+    })
+
+    it('hands back a different registry for a different container', () => {
+        expect(registryForContainer(dom.container)).not.toBe(registryForContainer(dom.another()))
+    })
+
+    it('writes nothing onto the container element', () => {
+        // The host owns that element. The registry is reached through a
+        // module-level WeakMap precisely so nothing is stamped on it.
+        const before = Object.getOwnPropertyNames(dom.container)
+        registryForContainer(dom.container)
+        expect(Object.getOwnPropertyNames(dom.container)).toEqual(before)
+    })
+
+    it('keeps two containers\' browser lists independent', () => {
+        const one = registryForContainer(dom.container)
+        const two = registryForContainer(dom.another())
+
+        one.add(fakeBrowser('a', one))
+        two.add(fakeBrowser('b', two))
+
+        expect(one.browsers.map(browser => browser.name)).toEqual(['a'])
+        expect(two.browsers.map(browser => browser.name)).toEqual(['b'])
+    })
+
+    it('keeps two containers\' current-browser pointers independent', () => {
+        const one = registryForContainer(dom.container)
+        const two = registryForContainer(dom.another())
+
+        const a = fakeBrowser('a', one)
+        const b = fakeBrowser('b', two)
+        one.add(a)
+        two.add(b)
+
+        expect(one.currentBrowser).toBe(a)
+        expect(two.currentBrowser).toBe(b)
+    })
+})
+
+describe('registry back-pointer', () => {
+
+    const dom = withContainers()
+
+    it('is set on construction', () => {
+        // Declared surface, per decision 9 -- `setCurrentBrowser(browser)`
+        // resolves through it, so it cannot be absent at any point in a
+        // browser's life, including during the `init()` that loads its dataset.
+        const browser = new HICBrowser(dom.container, {})
+        expect(browser.registry).toBe(registryForContainer(dom.container))
+    })
+
+    it('points two browsers in one container at one registry', () => {
+        const first = new HICBrowser(dom.container, {})
+        const second = new HICBrowser(dom.container, {})
+        expect(first.registry).toBe(second.registry)
+    })
+
+    it('points browsers in different containers at different registries', () => {
+        const first = new HICBrowser(dom.container, {})
+        const second = new HICBrowser(dom.another(), {})
+        expect(first.registry).not.toBe(second.registry)
+    })
+})
+
+describe('the browser panel, driven through its own DOM handlers', () => {
+
+    // The three gestures juicebox-web depends on -- select a panel, delete a
+    // panel, open a second one -- exercised through the click handlers
+    // `layoutController` wires, so what is under test is the whole route from
+    // event to registry, not a hand-called module function.
+
+    const dom = withContainers()
+
+    function click(element) {
+        element.dispatchEvent(new dom.window.MouseEvent('click', {bubbles: true}))
+    }
+
+    function navbarOf(browser) {
+        return browser.rootElement.querySelector('.hic-navbar-container')
+    }
+
+    it('selects the browser whose navbar was clicked', () => {
+        const registry = registryForContainer(dom.container)
+        const first = new HICBrowser(dom.container, {})
+        const second = new HICBrowser(dom.container, {})
+        registry.add(first)
+        registry.add(second)
+
+        click(navbarOf(first))
+
+        expect(getCurrentBrowser()).toBe(first)
+        expect(registry.currentBrowser).toBe(first)
+    })
+
+    it('deletes the browser whose delete button was clicked', () => {
+        const registry = registryForContainer(dom.container)
+        const first = new HICBrowser(dom.container, {})
+        const second = new HICBrowser(dom.container, {})
+        registry.add(first)
+        registry.add(second)
+
+        click(second.browserPanelDeleteButton)
+
+        expect(registry.browsers).toEqual([first])
+    })
+
+    it('leaves a second container untouched by either gesture', () => {
+        // The whole point of #479: juicebox-web's panel gestures must not reach
+        // across into another embed's list.
+        const mine = new HICBrowser(dom.container, {})
+        const theirs = new HICBrowser(dom.another(), {})
+        mine.registry.add(mine)
+        theirs.registry.add(theirs)
+
+        click(navbarOf(mine))
+        expect(theirs.registry.currentBrowser).toBe(theirs)
+
+        click(mine.browserPanelDeleteButton)
+        expect(theirs.registry.browsers).toEqual([theirs])
+    })
+})
+
+describe('the zero-argument getters', () => {
+
+    const dom = withContainers()
+
+    function twoRegistries() {
+        return [registryForContainer(dom.container), registryForContainer(dom.another())]
+    }
+
+    it('reports the most recently selected browser page-wide', () => {
+        // Today's semantics exactly: module `currentBrowser` was only ever
+        // "whoever setCurrentBrowser last received, from anywhere".
+        const [one, two] = twoRegistries()
+        const a = fakeBrowser('a', one)
+        const b = fakeBrowser('b', two)
+
+        setCurrentBrowser(a)
+        expect(getCurrentBrowser()).toBe(a)
+
+        setCurrentBrowser(b)
+        expect(getCurrentBrowser()).toBe(b)
+    })
+
+    it('reports the browsers of the registry owning the current browser', () => {
+        const [one, two] = twoRegistries()
+        const a = fakeBrowser('a', one)
+        const b = fakeBrowser('b', two)
+        one.register(a)
+        two.register(b)
+
+        setCurrentBrowser(a)
+        expect(getAllBrowsers()).toEqual([a])
+
+        setCurrentBrowser(b)
+        expect(getAllBrowsers()).toEqual([b])
+    })
+
+    it('clears the selection when setCurrentBrowser is given undefined', () => {
+        // A published export, and `select` has always documented the undefined
+        // case. There is no `browser.registry` to resolve through here, so the
+        // page-wide pointer is what names the registry to clear.
+        const [one] = twoRegistries()
+        const a = fakeBrowser('a', one)
+
+        setCurrentBrowser(a)
+        setCurrentBrowser(undefined)
+
+        expect(getCurrentBrowser()).toBeUndefined()
+        expect(one.currentBrowser).toBeUndefined()
+    })
+
+    it('clears nothing when setCurrentBrowser is given undefined with no selection', () => {
+        setCurrentBrowser(undefined)
+        expect(() => setCurrentBrowser(undefined)).not.toThrow()
+    })
+
+    it('re-selecting an already-current browser still moves the page-wide pointer', () => {
+        // `select` short-circuits when the browser is already its registry's
+        // current one. The page-wide pointer must move anyway, or a host that
+        // clicks back into the embed it started in gets the other embed.
+        const [one, two] = twoRegistries()
+        const a = fakeBrowser('a', one)
+        const b = fakeBrowser('b', two)
+
+        setCurrentBrowser(a)
+        setCurrentBrowser(b)
+        setCurrentBrowser(a)
+
+        expect(getCurrentBrowser()).toBe(a)
+    })
+})


### PR DESCRIPTION
Closes #479. Candidate 4 in `docs/architecture-review.html`; decisions 2, 4, 8 and 9 of [ADR-0004](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0004-browser-registry-per-container.md).

## What this does

One registry per host container element instead of one per page. A module-level `WeakMap<Element, BrowserRegistry>` in `js/browserRegistry.js` maps container to registry — deliberately not a property stamped on the container, because the host owns that element (decision 8).

`createBrowser` and `createBrowserList` resolve from their container argument; `setCurrentBrowser` and `deleteBrowser` from a new `browser.registry` back-pointer, set in the `HICBrowser` constructor so it holds during `init()` too, and declared in `js/publicApi.js` per decision 9. **There is no default registry left.**

Only the zero-argument getters need a policy:

- `getCurrentBrowser()` — the most recently selected browser page-wide. Byte-for-byte the old module `currentBrowser`, which was already just "whoever `setCurrentBrowser` last received, from anywhere".
- `getAllBrowsers()` — the browsers of the registry that owns that current browser.

Both are documented in place as single-embed conveniences, pointing multi-embed callers at the registry.

Internal callers stop going through the page-wide getters, since they all have a container or a browser in hand: `unsyncSelf`, the data loader's sync-and-compare, `init()`'s return value, and `restoreSession`'s clear and sync.

## Beyond the literal ticket

Both forced by removing the default registry, and both invisible in the single-embed case:

- `syncBrowsers` and `updateAllBrowsers` are gone from `js/createBrowser.js` — callers use `registry.sync()`, and the latter had no callers at all — and `deleteAllBrowsers` takes the container it must scope to. None are in `js/index.js`, so no consumer surface moves.
- Dataset-load syncing is now registry-scoped, which is decision 6's effect arriving early. There is nowhere else for it to resolve.

`session.js`'s `toJSON` stays page-wide: it is a published zero-argument export, and per-embed sessions are decision 5.

## The risky part

The issue calls this the risky ticket: a mistake silently changes what juicebox-web's `getAllBrowsers()` returns and nothing fails.

Verified against the juicebox-web checkout — it passes one element to both `hic.init` (`js/app.js:47`) and `hic.createBrowser` (`js/initializationHelper.js:426`), and `controlMapDropdown`'s `getBrowsers` callback is invoked lazily inside `sync()` rather than retained, so all 13 call sites resolve the one registry exactly as before.

Review found one real regression, fixed with tests: `setCurrentBrowser(undefined)` threw a `TypeError` where it used to clear the selection. It is the one call with no back-pointer to resolve through, so it falls back to the page-wide pointer.

## Tests

`test/testRegistryLookup.js` — container keying, the no-write-to-container promise, two independent registries, the `browser.registry` back-pointer, and the getter policy. Plus an integration block that drives the browser panel through the click handlers `layoutController` wires, asserting a second container is untouched by select and delete.

380 tests pass; build clean.

## Still owed

Runtime click-through against juicebox-web — browser panel add/delete/select and session save. Verified statically only; no headless browser available in the environment it was built in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)