### PR TITLE
Fall selection through when the current browser is deleted (#480)

### DIFF
--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -14,13 +14,13 @@ import {pairSynchable} from './syncGroup.js'
  * One registry owns one container element; `registryForContainer` below is how
  * every entry point finds the right one.
  *
- * Two things the ADR calls for are deliberately absent, because #478 was a lift
- * and #479 a re-keying, and neither may change observable behaviour:
+ * The registry holds the invariant *a non-empty registry has a current
+ * browser*: deleting the current one falls selection through to a survivor, and
+ * `currentBrowser` is `undefined` only while the registry is empty. Decision 7.
  *
- * - selection does not fall through on delete, so `currentBrowser` can still
- *   name a browser that has left the DOM. That is #475, ADR decision 7.
- * - the sync group is still each browser's own `synchedBrowsers` set. What the
- *   registry owns is the *membership rule*: whose browsers get paired.
+ * One thing the ADR calls for is still absent: the sync group is each browser's
+ * own `synchedBrowsers` set. What the registry owns is the *membership rule*:
+ * whose browsers get paired.
  */
 class BrowserRegistry {
 
@@ -92,6 +92,9 @@ class BrowserRegistry {
         browser.unsyncSelf()
         browser.rootElement.remove()
         this.browsers = this.browsers.filter(b => b !== browser)
+        if (browser === this.currentBrowser) {
+            this.select(this.browsers[0])
+        }
         this.refreshDeleteButtonVisibility()
     }
 
@@ -100,6 +103,7 @@ class BrowserRegistry {
             browser.rootElement.remove()
         }
         this.clear()
+        this.select(undefined)
     }
 
     async updateAll() {

--- a/test/testBrowserRegistry.js
+++ b/test/testBrowserRegistry.js
@@ -212,13 +212,45 @@ describe('BrowserRegistry', () => {
             expect(deleteButtonDisplays(registry)).toEqual(['block', 'block'])
         })
 
-        it('leaves the deleted browser current -- selection fall-through is #475, not this lift', () => {
+        it('falls selection through to a surviving browser and posts BrowserSelect for it', () => {
             const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
             registry.add(a)
+            registry.add(b)
+            selectEvents.length = 0
+
+            registry.delete(b)
+
+            expect(registry.currentBrowser).toBe(a)
+            expect(isSelected(a)).toBe(true)
+            expect(selectEvents.map(e => e.data)).toEqual([a])
+        })
+
+        it('leaves selection alone and posts nothing when the deleted browser is not current', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+            selectEvents.length = 0
 
             registry.delete(a)
 
-            expect(registry.currentBrowser).toBe(a)
+            expect(registry.currentBrowser).toBe(b)
+            expect(isSelected(b)).toBe(true)
+            expect(selectEvents).toHaveLength(0)
+        })
+
+        it('leaves selection undefined once deleting empties the registry', () => {
+            const a = fakeBrowser('a')
+            registry.add(a)
+            selectEvents.length = 0
+
+            registry.delete(a)
+
+            expect(registry.browsers).toEqual([])
+            expect(registry.currentBrowser).toBeUndefined()
+            expect(isSelected(a)).toBe(false)
+            expect(selectEvents).toHaveLength(0)
         })
     })
 
@@ -235,6 +267,20 @@ describe('BrowserRegistry', () => {
             expect(registry.browsers).toEqual([])
             expect(a.rootElement.removed).toBe(true)
             expect(b.rootElement.removed).toBe(true)
+        })
+
+        it('leaves selection undefined, the registry now being empty', () => {
+            const a = fakeBrowser('a')
+            const b = fakeBrowser('b')
+            registry.add(a)
+            registry.add(b)
+            selectEvents.length = 0
+
+            registry.deleteAll()
+
+            expect(registry.currentBrowser).toBeUndefined()
+            expect(isSelected(b)).toBe(false)
+            expect(selectEvents).toHaveLength(0)
         })
     })
 


### PR DESCRIPTION
Closes #480 and #475; decision 7 of [ADR-0004](https://github.com/aidenlab/juicebox.js/blob/master/docs/adr/0004-browser-registry-per-container.md).

## What this does

`BrowserRegistry.delete` removed the browser from the list and from the DOM but never touched the current-browser pointer. The deleted browser and its whole detached DOM subtree stayed reachable for the life of the page, and `getCurrentBrowser()` — an exported name — could hand a host a browser that is gone. `deleteAll` had the same hole.

Selection now falls through:

- `delete` — when the removed browser was the current one, `select(this.browsers[0])` picks a survivor. With an empty list that argument is `undefined`, which is already `select`'s "clear the selection" path, so the empty case needs no branch of its own.
- `deleteAll` — `select(undefined)` after clearing.

Both go through `select` rather than assigning the field, so the `hic-root-selected` class moves, `BrowserSelect` posts on a real transition and stays silent otherwise, and the page-wide `mostRecentlySelectedBrowser` is cleared when it named the browser going away.

This holds the invariant *a non-empty registry has a current browser* without widening `BrowserSelect`'s payload contract. The alternative — posting `BrowserSelect` with `undefined` — asks juicebox-web to handle a selection that vanished while browsers remain on the page, which it has never had to do.

The class doc in `js/browserRegistry.js` documented the dangling pointer as deliberately deferred to #475; that paragraph now states the invariant instead.

## Which survivor

`browsers[0]`, i.e. the oldest browser in the registry. The ADR says "another browser in the registry" and does not pick one; first-in-list is the cheapest rule that satisfies it, and with the panel layout it means selection lands on the leftmost remaining browser.

## Tests

Built test-first at the registry seam, driving `delete`/`deleteAll` with the browser-shaped doubles `test/testBrowserRegistry.js` already uses, and observing through `currentBrowser`, the selected class and the `BrowserSelect` event. Four cases, one per acceptance criterion:

| Case | |
|---|---|
| Current browser deleted → survivor selected, `BrowserSelect` posted for it | drove the `delete` change |
| Non-current deleted → selection untouched, nothing posted | passed on arrival |
| Delete empties the registry → selection `undefined`, nothing posted | passed on arrival |
| `deleteAll` → selection `undefined` | drove the `deleteAll` change |

The two middle cases were green the moment they were written — they pin branches the first change had already covered rather than having driven code themselves. Worth knowing when reading the suite.

The replaced test is `'leaves the deleted browser current -- selection fall-through is #475, not this lift'`, which asserted exactly the behaviour this PR removes.

383 tests pass.

## Still owed

Runtime click-through — deleting a browser panel via its delete button and confirming selection lands somewhere sensible in a host app. Verified at the unit seam only.

## Not in this PR

`clear()` still leaves `currentBrowser` naming a browser the registry no longer holds. It is the same class of hole, but outside #480's acceptance criteria, and both its callers are safe today: `deleteAll` now clears selection right after, and the session rebuild path re-adds immediately. Enforcing the invariant inside `clear()` rather than in its callers is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
