### PR TITLE
Move selectedGene and Alert onto the browser registry (#481)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,6 +79,12 @@ is the thing `initRegistry(container, config)` returns, and the unit of
 isolation that lets two embeds coexist on a page — see `docs/adr/0004`.
 _Avoid_: browser session, browser context, embed.
 
+**Alert dialog** — the modal a load failure or an unavailable option is reported
+in, one per registry, built in that registry's container on first use
+(`registry.presentAlert`). Distinct from igv-ui's `Alert` singleton, which is
+page-scoped and no longer used here: the singleton rebound itself to whichever
+container initialized last, so one embed's failures surfaced in another's.
+
 **Selected gene** — the gene name a search last resolved to, or a restored
 session last named. Per registry, because it is serialized per session. Not
 canonical state: `state.selectedGene` is a per-browser copy the state carries

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,11 +73,16 @@ locus changes and colour changes. Deleting it would push its fan-out back into
 `HICBrowser` and is not on the table — see `docs/adr/0002`.
 
 **Browser registry** — the owner of one embed: the browsers in a single host
-container, which of them is current, their sync group, and their teardown. One
-registry per container element. It is the thing `initRegistry(container, config)`
-returns, and the unit of isolation that lets two embeds coexist on a page —
-see `docs/adr/0004`.
+container, which of them is current, their sync group, their selected gene,
+their alert dialog, and their teardown. One registry per container element. It
+is the thing `initRegistry(container, config)` returns, and the unit of
+isolation that lets two embeds coexist on a page — see `docs/adr/0004`.
 _Avoid_: browser session, browser context, embed.
+
+**Selected gene** — the gene name a search last resolved to, or a restored
+session last named. Per registry, because it is serialized per session. Not
+canonical state: `state.selectedGene` is a per-browser copy the state carries
+for serialization, not something the view is derived from.
 
 **Session** vs **browser registry** — a *session* is serialized configuration:
 the JSON a user saves, pastes as a URL, or restores (`js/session.js`, `toJSON`,

--- a/dev/load-and-reset.html
+++ b/dev/load-and-reset.html
@@ -48,7 +48,6 @@
 <script type="module">
 
     import hic from "../js/index.js";
-    import {Alert} from "igv-ui"
     //import {GoogleAuth} from 'igv-utils'
     import { devMapUrl } from '../dev-proxy/map-url.js'
 
@@ -79,7 +78,6 @@
     }
 
     const container = document.getElementById("app-container");
-    Alert.init(container);
 
     (async function () {
 

--- a/dev/non_synched_maps.html
+++ b/dev/non_synched_maps.html
@@ -47,7 +47,6 @@
 <script type="module">
 
     import hic from "../js/index.js";
-    import {Alert} from "igv-ui"
     import { devMapUrl } from '../dev-proxy/map-url.js'
 
     // Dev-only: routes .hic reads on hosts that answer localhost with a bot challenge

--- a/dev/olga-assembly.html
+++ b/dev/olga-assembly.html
@@ -47,7 +47,6 @@
 <script type="module">
 
     import hic from "../js/index.js";
-    import {Alert} from "igv-ui"
     import { devMapUrl } from '../dev-proxy/map-url.js'
 
     // Dev-only: routes .hic reads on hosts that answer localhost with a bot challenge
@@ -65,7 +64,6 @@
 
     const container = document.getElementById("app-container");
 
-    Alert.init(container);
 
     hic.init(container, config)
         .then(function (hicBrowser) {

--- a/js/annotationWidget.js
+++ b/js/annotationWidget.js
@@ -21,7 +21,7 @@
  *
  */
 
-import { Alert, createColorSwatchSelector } from 'igv-ui';
+import { createColorSwatchSelector } from 'igv-ui';
 import { makeDraggable } from 'igv-ui';
 import HICEvent from './hicEvent.js';
 import Track2D from './track2D.js';
@@ -61,7 +61,7 @@ class AnnotationWidget {
                 this.annotationPanelElement.style.display =
                     this.annotationPanelElement.style.display === 'none' ? 'flex' : 'none';
             } else {
-                Alert.presentAlert(alertMessage);
+                this.browser.registry.presentAlert(alertMessage);
             }
 
             this.browser.hideMenu();

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -218,5 +218,19 @@ function getMostRecentlySelectedBrowser() {
     return mostRecentlySelectedBrowser
 }
 
+/**
+ * The registry owning the page-wide current browser, and `undefined` before
+ * anything has been selected.
+ *
+ * The resolution every zero-argument entry point makes: `getCurrentBrowser`,
+ * `getAllBrowsers`, `setCurrentBrowser(undefined)` and `session.toJSON` all
+ * have no container to resolve from and land here. Named once so the walk is
+ * not written out at each of them -- and so the single-embed convenience they
+ * share has a single place to be read about. See decision 4 of ADR-0004.
+ */
+function currentRegistry() {
+    return mostRecentlySelectedBrowser?.registry
+}
+
 export default BrowserRegistry
-export {registryForContainer, getMostRecentlySelectedBrowser}
+export {registryForContainer, getMostRecentlySelectedBrowser, currentRegistry}

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -1,3 +1,4 @@
+import {AlertDialog} from 'igv-ui'
 import EventBus from './eventBus.js'
 import HICEvent from './hicEvent.js'
 import {pairSynchable} from './syncGroup.js'
@@ -21,12 +22,47 @@ import {pairSynchable} from './syncGroup.js'
  * One thing the ADR calls for is still absent: the sync group is each browser's
  * own `synchedBrowsers` set. What the registry owns is the *membership rule*:
  * whose browsers get paired.
+ *
+ * It is also where the two page-scoped singletons that were plainly per-embed
+ * have landed: the selected gene and the alert dialog. See #481.
  */
 class BrowserRegistry {
 
-    constructor() {
+    /**
+     * @param {Element} [container] - the host element this registry owns.
+     *   Absent only in tests that exercise the registry without a document.
+     */
+    constructor(container) {
+        this.container = container
         this.browsers = []
         this.currentBrowser = undefined
+
+        /**
+         * The gene a search last resolved to, or a restored session last named.
+         *
+         * Per registry rather than page-wide because it is serialized *per
+         * session*: two embeds restoring different sessions have different
+         * selected genes, and the module-level `Globals.selectedGene` gave them
+         * one. #481.
+         */
+        this.selectedGene = undefined
+
+        // Built on first alert rather than in the constructor: constructing a
+        // registry must not put a dialog in the host's element.
+        this.alertDialog = undefined
+    }
+
+    /**
+     * Show `alert` in this embed's own dialog.
+     *
+     * igv-ui's `Alert` singleton is re-bound to a container on every
+     * initialization, so the last embed to initialize captured every other
+     * embed's alerts. Each registry owns an `AlertDialog` in the container it
+     * owns instead. #481.
+     */
+    presentAlert(alert, callback) {
+        this.alertDialog ??= new AlertDialog(this.container ?? document.body)
+        this.alertDialog.present(alert, callback)
     }
 
     /**
@@ -171,7 +207,7 @@ function registryForContainer(container) {
     let registry = registriesByContainer.get(container)
 
     if (undefined === registry) {
-        registry = new BrowserRegistry()
+        registry = new BrowserRegistry(container)
         registriesByContainer.set(container, registry)
     }
 

--- a/js/createBrowser.js
+++ b/js/createBrowser.js
@@ -4,7 +4,7 @@
 
 import { StringUtils } from 'igv-utils';
 import HICBrowser from './hicBrowser.js';
-import {registryForContainer, getMostRecentlySelectedBrowser} from './browserRegistry.js';
+import {registryForContainer, getMostRecentlySelectedBrowser, currentRegistry} from './browserRegistry.js';
 import {parseColorScale} from './colorScaleParser.js';
 import ContactMatrixView from "./contactMatrixView.js";
 
@@ -80,7 +80,7 @@ function deleteAllBrowsers(hicContainer) {
 function setCurrentBrowser(browser) {
 
     if (undefined === browser) {
-        getMostRecentlySelectedBrowser()?.registry.select(undefined);
+        currentRegistry()?.select(undefined);
         return;
     }
 
@@ -117,7 +117,7 @@ function getCurrentBrowser() {
  * is the other reason to hold a registry rather than ask page-wide.
  */
 function getAllBrowsers() {
-    return getMostRecentlySelectedBrowser()?.registry.browsers || [];
+    return currentRegistry()?.browsers || [];
 }
 
 function normalizeConfig(config) {

--- a/js/createWidgets.js
+++ b/js/createWidgets.js
@@ -34,7 +34,6 @@ import RatioColorScale from "./ratioColorScale.js"
 import DiffColorScale from "./diffColorScale.js"
 import ContactMatrixView from "./contactMatrixView.js"
 import ImageTileSource from "./imageTileSource.js"
-import {Alert} from "igv-ui"
 import ChromosomeSelector from "./chromosomeSelector.js"
 import AnnotationWidget from "./annotationWidget.js"
 
@@ -97,7 +96,7 @@ function createWidgets(browser) {
             colorScaleChanged: (scale) => coordinator.onColorScale(scale),
 
             normalizationUnavailable: (requested, effective) => {
-                Alert.presentAlert(`Normalization option ${requested} unavailable at this resolution.`);
+                browser.registry.presentAlert(`Normalization option ${requested} unavailable at this resolution.`);
                 coordinator.onNormalizationExternalChange(effective);
                 // The source never writes canonical state, so the correction
                 // lands here. Still outside the setView chokepoint, as it was

--- a/js/dataLoader.js
+++ b/js/dataLoader.js
@@ -21,7 +21,6 @@
  */
 
 import igv from 'igv'
-import {Alert} from 'igv-ui'
 import {FileUtils} from 'igv-utils'
 import Dataset, { HiCDataset } from './hicDataset.js'
 import State from './hicState.js'
@@ -88,7 +87,7 @@ class DataLoader {
 
             const hicFileAlert = str => {
                 this.browser.coordinator.onNormalizationExternalChange('NONE');
-                Alert.presentAlert(str);
+                this.browser.registry.presentAlert(str);
             };
 
             const dataset = await Dataset.loadDataset(Object.assign({alert: hicFileAlert}, config));
@@ -189,7 +188,7 @@ class DataLoader {
             // tell is a response header it never sees. Everything else is left to the host, which
             // may already report the rethrow — see issue #441.
             if (isBotChallenge(error)) {
-                presentError("Error loading map", error);
+                presentError(this.browser.registry, "Error loading map", error);
             }
 
             throw error;
@@ -291,7 +290,7 @@ class DataLoader {
 
             const hicFileAlert = str => {
                 this.browser.coordinator.onNormalizationExternalChange('NONE');
-                Alert.presentAlert(str);
+                this.browser.registry.presentAlert(str);
             };
 
             const controlDataset = await Dataset.loadDataset(Object.assign({alert: hicFileAlert}, config));
@@ -318,7 +317,7 @@ class DataLoader {
 
                 return controlDataset;
             } else {
-                Alert.presentAlert(
+                this.browser.registry.presentAlert(
                     '"B" map genome (' + controlDataset.genomeId + ') does not match "A" map genome (' +
                     this.browser.genome.id + ')'
                 );
@@ -327,7 +326,7 @@ class DataLoader {
         } catch (error) {
             // Same reasoning as loadHicFile: report only the failure the host app cannot explain.
             if (isBotChallenge(error)) {
-                presentError("Error loading control map", error);
+                presentError(this.browser.registry, "Error loading control map", error);
             }
 
             throw error;
@@ -426,7 +425,7 @@ class DataLoader {
             }
 
         } catch (error) {
-            presentError(errorPrefix, error);
+            presentError(this.browser.registry, errorPrefix, error);
             console.error(error);
         } finally {
             this.browser.contactMatrixView.stopSpinner();

--- a/js/globals.js
+++ b/js/globals.js
@@ -1,3 +1,0 @@
-const Globals = {}
-
-export {Globals}

--- a/js/hicBrowser.js
+++ b/js/hicBrowser.js
@@ -27,7 +27,6 @@
 
 import {InputDialog, DOMUtils} from 'igv-ui'
 import * as hicUtils from './hicUtils.js'
-import {Globals} from "./globals.js"
 import EventBus from "./eventBus.js"
 import LayoutController, {setViewportSize} from './layoutController.js'
 import { geneSearch } from './geneSearch.js'
@@ -594,8 +593,8 @@ class HICBrowser {
         const upperName = trimmedName.toUpperCase();
 
         if (this.genome.featureDB.has(upperName)) {
-            Globals.selectedGene = trimmedName
-            this.state.selectedGene = Globals.selectedGene
+            this.registry.selectedGene = trimmedName
+            this.state.selectedGene = trimmedName
             const {chr, start, end } = this.genome.featureDB.get(upperName)
 
             // Internally, loci are 0-based. parseLocusString() assumes and user-provided locus which is 1-based
@@ -604,8 +603,8 @@ class HICBrowser {
 
         const geneResult = await geneSearch(this.genome.id, trimmedName);
         if (geneResult) {
-            Globals.selectedGene = trimmedName;
-            this.state.selectedGene = Globals.selectedGene;
+            this.registry.selectedGene = trimmedName;
+            this.state.selectedGene = trimmedName;
             return this.parseLocusString(geneResult)
         }
 
@@ -868,8 +867,8 @@ class HICBrowser {
         jsonOBJ.state = this.state.toJSON()
 
         jsonOBJ.colorScale = this.contactMatrixView.getColorScale().stringify()
-        if (Globals.selectedGene) {
-            jsonOBJ.selectedGene = Globals.selectedGene
+        if (this.registry.selectedGene) {
+            jsonOBJ.selectedGene = this.registry.selectedGene
         }
         let nviString = this.dataset.hicFile.config.nvi
         if (nviString) {

--- a/js/init.js
+++ b/js/init.js
@@ -24,11 +24,12 @@
 import {extractConfig} from "./urlUtils.js"
 import {registryForContainer} from "./browserRegistry.js"
 import {restoreSession} from "./session.js"
-import {Alert} from "igv-ui"
 
 async function init(container, config) {
 
-    Alert.init(container);
+    // No `Alert.init(container)` here: igv-ui's singleton was re-bound on every
+    // initialization, so the last embed to initialize captured every embed's
+    // alerts. Each registry now owns its own dialog -- see #481.
 
     if (false !== config.queryParametersSupported) {
         const queryConfig = await extractConfig(window.location.href);

--- a/js/session.js
+++ b/js/session.js
@@ -1,5 +1,5 @@
 import {createBrowserList, deleteAllBrowsers} from "./createBrowser.js"
-import {registryForContainer, getMostRecentlySelectedBrowser} from "./browserRegistry.js"
+import {registryForContainer, currentRegistry} from "./browserRegistry.js"
 import {StringUtils, BGZip} from "igv-utils";
 import {expandUrlShortcuts} from "./urlUtils.js";
 
@@ -12,10 +12,10 @@ function toJSON() {
     // "whichever embed was touched last" is decision 5 of ADR-0004, which needs
     // `registry.toJSON()` and lands with the per-embed session work.
     //
-    // This is `getAllBrowsers()` written out, which is also what names the
-    // registry the selected gene is read from: one embed's session carries that
-    // embed's gene, not the page's. #481.
-    const registry = getMostRecentlySelectedBrowser()?.registry;
+    // The same registry `getAllBrowsers()` resolves, which is also what names
+    // the registry the selected gene is read from: one embed's session carries
+    // that embed's gene, not the page's. #481.
+    const registry = currentRegistry();
 
     for (let browser of registry?.browsers || []) {
         browserJson.push(browser.toJSON());

--- a/js/session.js
+++ b/js/session.js
@@ -1,6 +1,5 @@
-import {createBrowserList, deleteAllBrowsers, getAllBrowsers} from "./createBrowser.js"
-import {registryForContainer} from "./browserRegistry.js"
-import {Globals} from "./globals.js"
+import {createBrowserList, deleteAllBrowsers} from "./createBrowser.js"
+import {registryForContainer, getMostRecentlySelectedBrowser} from "./browserRegistry.js"
 import {StringUtils, BGZip} from "igv-utils";
 import {expandUrlShortcuts} from "./urlUtils.js";
 
@@ -12,14 +11,19 @@ function toJSON() {
     // container to resolve from. Serializing one embed's session rather than
     // "whichever embed was touched last" is decision 5 of ADR-0004, which needs
     // `registry.toJSON()` and lands with the per-embed session work.
-    const allBrowsers = getAllBrowsers();
-    for (let browser of allBrowsers) {
+    //
+    // This is `getAllBrowsers()` written out, which is also what names the
+    // registry the selected gene is read from: one embed's session carries that
+    // embed's gene, not the page's. #481.
+    const registry = getMostRecentlySelectedBrowser()?.registry;
+
+    for (let browser of registry?.browsers || []) {
         browserJson.push(browser.toJSON());
     }
     jsonOBJ.browsers = browserJson;
 
-    if (Globals.selectedGene) {
-        jsonOBJ["selectedGene"] = Globals.selectedGene;
+    if (registry?.selectedGene) {
+        jsonOBJ["selectedGene"] = registry.selectedGene;
     }
 
     const captionDiv = document.getElementById('hic-caption');
@@ -83,7 +87,7 @@ async function restoreSession(container, session) {
     }
 
     if (session.hasOwnProperty("selectedGene")) {
-        Globals.selectedGene = session.selectedGene;
+        registryForContainer(container).selectedGene = session.selectedGene;
     }
     if (session.hasOwnProperty("caption")) {
         const captionText = session.caption;

--- a/js/urlUtils.js
+++ b/js/urlUtils.js
@@ -135,11 +135,17 @@ async function extractConfig(queryString) {
 
     // `selectedGene` used to leave `decodeQuery` as a write to a page-scoped
     // global, which is how it reached `restoreSession` from the two paths that
-    // do not put it at the top level: a bare query string with no `hicUrl`, and
-    // the legacy `juicebox=` form, where it sits inside each browser's config.
-    // It now rides the session config instead, so it can land on one registry.
-    // A session's own value wins, and after that the last writer does -- which
-    // is the order the successive global writes produced. #481.
+    // do not put it at the top level: a query string carrying the gene beside a
+    // `session=`, and the legacy `juicebox=` form, where it sits inside each
+    // browser's config. It now rides the session config instead, so it can land
+    // on one registry. A session's own value wins, and after that the last
+    // writer does -- which is the order the successive global writes produced.
+    //
+    // Not preserved: `?selectedGene=` on a URL naming no map and no session at
+    // all. There being no session config to ride, the gene is dropped rather
+    // than reaching whatever config the host passed `init()`. juicebox never
+    // writes such a URL -- every URL it produces carries the gene inside the
+    // session it also writes. #481.
     if (sessionConfig && undefined === sessionConfig.selectedGene) {
         const fromBrowsers = (sessionConfig.browsers || []).map(b => b.selectedGene).filter(Boolean).pop();
         const selectedGene = queryConfig.selectedGene || fromBrowsers;

--- a/js/urlUtils.js
+++ b/js/urlUtils.js
@@ -22,7 +22,6 @@
  */
 import State from './hicState.js';
 import {parseColorScale} from "./colorScaleParser.js"
-import {Globals} from "./globals.js";
 import {StringUtils, BGZip} from 'igv-utils'
 import {isFile} from './fileUtils.js'
 import {igvxhr} from 'igv-utils'
@@ -134,6 +133,21 @@ async function extractConfig(queryString) {
         sessionConfig = queryConfig;
     }
 
+    // `selectedGene` used to leave `decodeQuery` as a write to a page-scoped
+    // global, which is how it reached `restoreSession` from the two paths that
+    // do not put it at the top level: a bare query string with no `hicUrl`, and
+    // the legacy `juicebox=` form, where it sits inside each browser's config.
+    // It now rides the session config instead, so it can land on one registry.
+    // A session's own value wins, and after that the last writer does -- which
+    // is the order the successive global writes produced. #481.
+    if (sessionConfig && undefined === sessionConfig.selectedGene) {
+        const fromBrowsers = (sessionConfig.browsers || []).map(b => b.selectedGene).filter(Boolean).pop();
+        const selectedGene = queryConfig.selectedGene || fromBrowsers;
+        if (selectedGene) {
+            sessionConfig.selectedGene = selectedGene;
+        }
+    }
+
     // Fix certain defaults
     if (sessionConfig) {
         if (sessionConfig.browsers) {
@@ -235,7 +249,7 @@ function decodeQuery(query, uriDecode) {
     }
 
     if (selectedGene) {
-        Globals.selectedGene = selectedGene;
+        config.selectedGene = selectedGene;
     }
 
     config.cycle = cycle;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,3 @@
-import {Alert} from 'igv-ui'
 import {isFile} from "./fileUtils.js"
 
 function createDOMFromHTMLString(string) {
@@ -88,10 +87,20 @@ const botChallengeMessage =
     "provider's allowlist. " +
     "See https://github.com/aidenlab/juicebox.js/issues/441";
 
-function presentError(prefix, error) {
+/**
+ * Report a failed load in one embed's own alert dialog.
+ *
+ * The registry is the alert surface -- passed in rather than reached for,
+ * because this module has no browser to resolve one from. See #481.
+ *
+ * @param {BrowserRegistry} registry - the registry whose container shows this
+ * @param {string} prefix - what was being loaded, e.g. "Error loading map"
+ * @param {Error} error - the error the load failed with
+ */
+function presentError(registry, prefix, error) {
 
     if (isBotChallenge(error)) {
-        Alert.presentAlert(`${prefix}: ${botChallengeMessage}`);
+        registry.presentAlert(`${prefix}: ${botChallengeMessage}`);
         return;
     }
 
@@ -106,7 +115,7 @@ function presentError(prefix, error) {
     // that is the only reliable key. Codes arrive as either numbers or strings; object keys
     // normalize both. See issue #442.
     const msg = Object.hasOwn(httpMessages, error.code) ? httpMessages[error.code] : error.message;
-    Alert.presentAlert(`${prefix}: ${msg}`);
+    registry.presentAlert(`${prefix}: ${msg}`);
 }
 
 export { createDOMFromHTMLString, getOffset, parseRgbString, prettyPrint, extractName, presentError, isBotChallenge, hitTestBbox }

--- a/test/testDataLoaderErrors.js
+++ b/test/testDataLoaderErrors.js
@@ -6,13 +6,6 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 const presented = [];
 
-vi.mock('igv-ui', () => ({
-    Alert: {
-        presentAlert: (message) => presented.push(message),
-        init: () => undefined
-    }
-}));
-
 const loadDataset = vi.fn();
 
 vi.mock('../js/hicDataset.js', () => ({
@@ -29,7 +22,9 @@ function stubBrowser() {
         contactMatrixView: { startSpinner: () => undefined },
         contactMapLabel: { textContent: "", title: "" },
         userInteractionShield: { style: {} },
-        controlDataset: undefined
+        controlDataset: undefined,
+        // Alerts land in the browser's own embed, not a page-wide singleton -- #481.
+        registry: { presentAlert: (message) => presented.push(message) }
     };
 }
 

--- a/test/testEmbedScoping.js
+++ b/test/testEmbedScoping.js
@@ -1,0 +1,194 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import {JSDOM} from 'jsdom'
+
+/**
+ * igv-ui builds its DOMPurify at import time, from whatever `window` is then.
+ * `test/setup.js` installs a hand-rolled document mock, which leaves purify
+ * inert and `AlertDialog.present` throwing on a method that was never defined.
+ * Priming a real window before the dynamic imports below is what lets the alert
+ * tests exercise the real dialog rather than a stand-in for it. The window
+ * outlives the primed import deliberately -- purify keeps using it.
+ */
+const priming = new JSDOM('<!doctype html><html><body></body></html>')
+const mockedWindow = globalThis.window
+const mockedDocument = globalThis.document
+globalThis.window = priming.window
+globalThis.document = priming.window.document
+
+const {registryForContainer} = await import('../js/browserRegistry.js')
+const {toJSON, restoreSession} = await import('../js/session.js')
+const {default: HICBrowser} = await import('../js/hicBrowser.js')
+const {withDOM} = await import('./utils/browserFixture.js')
+
+globalThis.window = mockedWindow
+globalThis.document = mockedDocument
+
+/**
+ * The two page-scoped singletons that were plainly per-embed -- the selected
+ * gene and the alert dialog -- now live on the registry. #481, the scope
+ * section of ADR-0004.
+ *
+ * What each test here asserts is *which embed* a piece of state belongs to, so
+ * every one of them stands up two containers. A single-embed assertion would
+ * pass against the page-scoped code these replace.
+ *
+ * Real elements and a real `AlertDialog`: the claim is that an alert lands in
+ * the container its own registry owns, and only the DOM can answer that.
+ */
+
+function withContainers() {
+
+    const context = {}
+    let fixture
+
+    beforeEach(() => {
+        fixture = withDOM()
+        context.window = fixture.window
+        context.container = fixture.container
+        context.another = () => {
+            const element = fixture.window.document.createElement('div')
+            fixture.window.document.body.appendChild(element)
+            return element
+        }
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    return context
+}
+
+describe('selectedGene', () => {
+
+    const dom = withContainers()
+
+    it('is undefined on a fresh registry', () => {
+        expect(registryForContainer(dom.container).selectedGene).toBeUndefined()
+    })
+
+    it('holds a different gene in each of two registries at once', () => {
+        const one = registryForContainer(dom.container)
+        const two = registryForContainer(dom.another())
+
+        one.selectedGene = 'ace'
+        two.selectedGene = 'egfr'
+
+        expect(one.selectedGene).toBe('ace')
+        expect(two.selectedGene).toBe('egfr')
+    })
+
+    it('is written by a gene search to the searching browser\'s own registry', async () => {
+        const mine = new HICBrowser(dom.container, {})
+        const theirs = new HICBrowser(dom.another(), {})
+
+        for (const browser of [mine, theirs]) {
+            browser.state = {}
+            browser.genome = {featureDB: new Map([['ACE', {chr: 'chr17', start: 61554422, end: 61575741}]])}
+            // The locus parse is a separate concern, and needs a dataset.
+            browser.parseLocusString = locus => locus
+        }
+
+        await mine.lookupFeatureOrGene('ace')
+
+        expect(mine.registry.selectedGene).toBe('ace')
+        expect(theirs.registry.selectedGene).toBeUndefined()
+    })
+
+    it('is restored onto the registry owning the container it was restored into', async () => {
+        const other = dom.another()
+
+        await restoreSession(dom.container, {browsers: [], selectedGene: 'ace'})
+
+        expect(registryForContainer(dom.container).selectedGene).toBe('ace')
+        expect(registryForContainer(other).selectedGene).toBeUndefined()
+    })
+
+    it('is serialized from the embed whose browser is current, not page-wide', () => {
+        // `toJSON()` is a zero-argument export with no container to resolve
+        // from, so it follows the page-wide selection -- the same
+        // single-embed convenience `getAllBrowsers()` carries. What it must not
+        // do is serialize one embed's browsers beside another embed's gene.
+        const one = registryForContainer(dom.container)
+        const two = registryForContainer(dom.another())
+        one.selectedGene = 'ace'
+        two.selectedGene = 'egfr'
+
+        for (const [registry, name] of [[one, 'a'], [two, 'b']]) {
+            registry.register(fakeBrowser(name, registry))
+        }
+
+        two.select(two.browsers[0])
+        expect(toJSON().selectedGene).toBe('egfr')
+
+        one.select(one.browsers[0])
+        expect(toJSON().selectedGene).toBe('ace')
+    })
+
+    it('is left out of a session when the embed has no selected gene', () => {
+        const registry = registryForContainer(dom.container)
+        registry.add(fakeBrowser('a', registry))
+
+        expect(Object.hasOwn(toJSON(), 'selectedGene')).toBe(false)
+    })
+})
+
+describe('alerts', () => {
+
+    const dom = withContainers()
+
+    function alertTextIn(container) {
+        const dialog = container.querySelector('.igv-ui-alert-dialog-container')
+        return dialog && dialog.querySelector('.igv-ui-alert-dialog-body-copy').textContent
+    }
+
+    it('surface in the container of the registry that raised them', () => {
+        const other = dom.another()
+
+        registryForContainer(dom.container).presentAlert('mine')
+
+        expect(alertTextIn(dom.container)).toBe('mine')
+        expect(alertTextIn(other)).toBeNull()
+    })
+
+    it('reach each embed separately rather than the last one to initialize', () => {
+        // The bug: igv-ui's Alert singleton was re-bound on every `init()`, so
+        // whichever embed initialized last captured every embed's alerts.
+        const other = dom.another()
+
+        registryForContainer(dom.container).presentAlert('mine')
+        registryForContainer(other).presentAlert('theirs')
+
+        expect(alertTextIn(dom.container)).toBe('mine')
+        expect(alertTextIn(other)).toBe('theirs')
+    })
+
+    it('builds one dialog per registry, however many alerts it raises', () => {
+        const registry = registryForContainer(dom.container)
+
+        registry.presentAlert('first')
+        registry.presentAlert('second')
+
+        expect(dom.container.querySelectorAll('.igv-ui-alert-dialog-container')).toHaveLength(1)
+        expect(alertTextIn(dom.container)).toBe('second')
+    })
+
+    it('puts no dialog in the container until something is alerted', () => {
+        registryForContainer(dom.container)
+
+        expect(dom.container.querySelector('.igv-ui-alert-dialog-container')).toBeNull()
+    })
+})
+
+/** Carries only what the registry and `session.toJSON` read. */
+function fakeBrowser(name, registry) {
+    return {
+        name,
+        registry,
+        rootElement: {classList: {add: () => undefined, remove: () => undefined}},
+        browserPanelDeleteButton: {style: {display: 'none'}},
+        synchedBrowsers: new Set(),
+        unsyncSelf: () => undefined,
+        toJSON: () => ({name})
+    }
+}

--- a/test/testPresentError.js
+++ b/test/testPresentError.js
@@ -2,17 +2,14 @@
  * presentError maps HTTP status codes to friendly alert text. The lookup used to be keyed on
  * error.message, so it never fired. See issue #442.
  */
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach } from 'vitest';
+
+import { presentError } from "../js/utils.js";
 
 const presented = [];
 
-vi.mock('igv-ui', () => ({
-    Alert: {
-        presentAlert: (message) => presented.push(message)
-    }
-}));
-
-const { presentError } = await import("../js/utils.js");
+/** The one thing presentError asks of a registry. */
+const registry = { presentAlert: (message) => presented.push(message) };
 
 function alertFor(message, code, headers) {
     const error = Error(message);
@@ -22,7 +19,7 @@ function alertFor(message, code, headers) {
     if (headers !== undefined) {
         error.headers = headers;
     }
-    presentError("Error loading map", error);
+    presentError(registry, "Error loading map", error);
     return presented.at(-1);
 }
 

--- a/test/testTrackUrlMapping.js
+++ b/test/testTrackUrlMapping.js
@@ -12,7 +12,7 @@ vi.mock('igv', () => ({
 }));
 
 vi.mock('igv-ui', () => ({
-    Alert: { presentAlert: (message) => { throw Error(message) }, init: () => undefined },
+    AlertDialog: class {},
     InputDialog: class {},
     DOMUtils: {}
 }));
@@ -45,7 +45,9 @@ function stubBrowser() {
         contactMatrixView: { startSpinner: () => undefined, stopSpinner: () => undefined },
         layoutController: { updateLayoutWithTracks: () => undefined },
         updateLayout: async () => undefined,
-        coordinator: { onTrackLoad2D: () => undefined }
+        coordinator: { onTrackLoad2D: () => undefined },
+        // An alert here is a test failure: these loads are expected to succeed.
+        registry: { presentAlert: (message) => { throw Error(message) } }
     };
 }
 
@@ -155,6 +157,8 @@ describe("1D track loading", function () {
  */
 function sessionTracksFor(trackConfigs, tracks2D = []) {
     const stub = {
+        // A real browser always has one; toJSON reads the selected gene off it -- #481.
+        registry: {},
         dataset: { url: "https://example.org/x.hic", hicFile: { config: {} } },
         state: { toJSON: () => ({}) },
         contactMatrixView: {


### PR DESCRIPTION
Closes #481. Candidate 4 of the architecture review; the scope section of [ADR-0004](../blob/master/docs/adr/0004-browser-registry-per-container.md).

Two page-scoped singletons become per-embed, so two juicebox instances on one page stop stepping on each other.

## selectedGene

`Globals.selectedGene` was a field on a module-level object shared by every instance, yet it is serialized *per session* — two embeds restoring different sessions shared one selected gene. It moves onto the registry, and `js/globals.js` goes with it, having held nothing else.

The one path that reached it without a container was `decodeQuery`, which wrote the global as a side effect. It now puts the gene on the config it returns, and `extractConfig` hoists it to the top level for the two URL forms that don't already carry it there — a gene beside a `session=`, and the legacy `juicebox=` form, where it sits inside each browser's config.

**One case is not preserved:** `?selectedGene=` on a URL naming no map and no session at all. There is no session config for it to ride, so it is dropped rather than reaching whatever config the host passed `init()`. juicebox never writes such a URL — every URL it produces carries the gene inside the session it also writes. Documented at the call site.

## Alerts

igv-ui's `Alert` singleton was re-bound to a container on every initialization, so the last embed to initialize captured every embed's alerts. Each registry owns an `AlertDialog` in its own container instead, built on first use so constructing a registry puts nothing in the host's element. `presentError` takes the registry to report through.

`Alert.init(container)` is gone from `init.js`, and from three `dev/*.html` pages that mirrored it. **Worth checking before release:** juicebox no longer initializes igv-ui's page-wide singleton as a side effect. If juicebox-web or Spacewalk call `Alert.presentAlert` themselves and relied on juicebox having bound it, their alerts now fall back to `document.body`.

## Deliberately untouched

`inProgressCache` (keyed by URL, so sharing it across embeds is a benefit) and the `--hic-viewport-*` custom properties (#477).

## Tests

`test/testEmbedScoping.js`, 10 tests. Every one stands up two containers, so a single-embed assertion cannot pass them. The alert tests exercise the real igv-ui `AlertDialog` against real elements — the claim is that an alert lands in the container its own registry owns, and only the DOM can answer that. Mutation-checked against a shared dialog: two fail.

The file primes a real JSDOM before its imports, because igv-ui builds its DOMPurify at import time and `test/setup.js`'s document mock leaves it inert.

Full suite green: 393 tests, 26 files. Bundle builds.

## Not done

`registry.selectedGene` and `registry.presentAlert` are **not** declared in `js/publicApi.js`. The registry's other members aren't either, so declaring these two would set a new precedent — but `browser.registry` *is* published surface, so whether the registry's own members should be enumerated there is a live question, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)