### PR TITLE
Sessions become browser registry methods (#482)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,6 +96,14 @@ the JSON a user saves, pastes as a URL, or restores (`js/session.js`, `toJSON`,
 that produces and consumes one. A registry has a session; it is not one. Never
 call the registry a session.
 
+A session describes **one embed**, not the page: `registry.toJSON()` and
+`registry.restoreSession(config)` are where the work happens, and the exported
+functions of the same name delegate to a registry — `restoreSession` to the one
+owning the container it is given, `toJSON` to the same page-wide default the
+zero-argument getters use. The only part of a session no registry owns is the
+**caption**, a single `#hic-caption` element outside every container that two
+embeds share.
+
 **Update** vs **repaint** — not synonyms. A **repaint** redraws everything from
 current state: rulers, track pairs, contact matrix, once, with no coordination.
 An **update** wraps a repaint in the things that must happen around it —

--- a/js/browserRegistry.js
+++ b/js/browserRegistry.js
@@ -2,6 +2,13 @@ import {AlertDialog} from 'igv-ui'
 import EventBus from './eventBus.js'
 import HICEvent from './hicEvent.js'
 import {pairSynchable} from './syncGroup.js'
+import {expandSessionUrlShortcuts} from './urlUtils.js'
+// A cycle, deliberately: `createBrowser.js` resolves its registry from a
+// container, and `restoreSession` below needs browsers built. Neither module
+// touches the other while it is being evaluated, so the cycle is inert -- and
+// the alternative, letting the registry construct an `HICBrowser` itself, would
+// break the rule that keeps it testable.
+import {createBrowserList} from './createBrowser.js'
 
 /**
  * The owner of one embed's browsers: the list, which of them is current, and
@@ -158,6 +165,56 @@ class BrowserRegistry {
         for (const [b1, b2] of pairSynchable(browsers || this.browsers)) {
             b1.synchedBrowsers.add(b2)
             b2.synchedBrowsers.add(b1)
+        }
+    }
+
+    /**
+     * Serialize this embed as a session: its browsers, and the gene it has
+     * selected.
+     *
+     * A session describes one embed, not the page. That is the whole point of
+     * decision 5 of ADR-0004: the exported zero-argument `toJSON()` has no
+     * container to resolve from and so follows the page-wide selection, but
+     * what it resolves to is *a registry*, and everything in the document comes
+     * from that one registry.
+     */
+    toJSON() {
+
+        const json = {browsers: this.browsers.map(browser => browser.toJSON())}
+
+        if (this.selectedGene) {
+            json.selectedGene = this.selectedGene
+        }
+
+        return json
+    }
+
+    /**
+     * Replace this embed's browsers with the ones a session names.
+     *
+     * The load-bearing half of #384: restoring is something one embed does to
+     * itself, so the delete that opens it reaches only this registry's
+     * browsers, and a host restoring into its second container keeps the first
+     * one's DOM.
+     *
+     * The caption is not here -- it is a single page element outside every
+     * container, so the exported `restoreSession` handles it. Everything else a
+     * session carries belongs to one embed.
+     */
+    async restoreSession(session) {
+
+        this.deleteAll()
+
+        expandSessionUrlShortcuts(session)
+
+        if (Object.hasOwn(session, 'selectedGene')) {
+            this.selectedGene = session.selectedGene
+        }
+
+        await createBrowserList(this.container, session)
+
+        if (false !== session.syncDatasets) {
+            this.sync()
         }
     }
 

--- a/js/session.js
+++ b/js/session.js
@@ -1,31 +1,36 @@
-import {createBrowserList, deleteAllBrowsers} from "./createBrowser.js"
 import {registryForContainer, currentRegistry} from "./browserRegistry.js"
-import {StringUtils, BGZip} from "igv-utils";
-import {expandUrlShortcuts} from "./urlUtils.js";
+import {BGZip} from "igv-utils";
 
+/**
+ * The exported session functions -- the names both known host apps import, per
+ * ADR-0003.
+ *
+ * A session describes *one embed*, so the work is `registry.toJSON()` and
+ * `registry.restoreSession(config)`; these three keep their published
+ * signatures and delegate. Decision 5 of ADR-0004, #482.
+ *
+ * What is left here rather than on the registry is the caption: a single
+ * `#hic-caption` element outside every container, which two embeds on a page
+ * share and no registry can own.
+ */
+
+/**
+ * Serialize a session: the browsers of one embed, its selected gene, and the
+ * page caption.
+ *
+ * Which embed is the page-wide one, because `toJSON()` is a published
+ * zero-argument export with no container to resolve from -- the same
+ * single-embed convenience `getAllBrowsers()` carries. Once resolved, the whole
+ * document comes from that one registry: `registry.toJSON()` is where a session
+ * is actually written. Decision 5 of ADR-0004, #482.
+ */
 function toJSON() {
-    const jsonOBJ = {};
-    const browserJson = [];
 
-    // Page-wide, because `toJSON()` is a published zero-argument export with no
-    // container to resolve from. Serializing one embed's session rather than
-    // "whichever embed was touched last" is decision 5 of ADR-0004, which needs
-    // `registry.toJSON()` and lands with the per-embed session work.
-    //
-    // The same registry `getAllBrowsers()` resolves, which is also what names
-    // the registry the selected gene is read from: one embed's session carries
-    // that embed's gene, not the page's. #481.
-    const registry = currentRegistry();
+    const jsonOBJ = currentRegistry()?.toJSON() || {browsers: []};
 
-    for (let browser of registry?.browsers || []) {
-        browserJson.push(browser.toJSON());
-    }
-    jsonOBJ.browsers = browserJson;
-
-    if (registry?.selectedGene) {
-        jsonOBJ["selectedGene"] = registry.selectedGene;
-    }
-
+    // The caption is the one part of a session no registry owns: it is a single
+    // page element outside every container, so it is read here rather than in
+    // the registry. Two embeds on a page share it.
     const captionDiv = document.getElementById('hic-caption');
     if (captionDiv) {
         var captionText = captionDiv.textContent;
@@ -46,63 +51,25 @@ function compressedSession() {
 }
 
 
+/**
+ * Replace the browsers in `container`'s embed with the ones `session` names.
+ *
+ * The container argument has always implied this, and since #479 keyed
+ * registries by container it has been true. What #482 adds is that the session
+ * is the *registry's* -- restoring is something one embed does to itself, not a
+ * page-wide operation aimed at a container. A host initializing a second embed
+ * keeps the first one's DOM either way; #384.
+ */
 async function restoreSession(container, session) {
 
-    deleteAllBrowsers(container);
-
-    // Expand URL shortcuts in session config for backward compatibility
-    // This ensures sessions passed directly to restoreSession (not through extractConfig)
-    // still work with URL shortcuts like *s3/, *enc/, etc.
-    if (session.browsers) {
-        for (let browser of session.browsers) {
-            if (browser.url) {
-                browser.url = expandUrlShortcuts(browser.url);
-            }
-            if (browser.controlUrl) {
-                browser.controlUrl = expandUrlShortcuts(browser.controlUrl);
-            }
-            if (browser.tracks) {
-                for (let track of browser.tracks) {
-                    if (track.url) {
-                        track.url = expandUrlShortcuts(track.url);
-                    }
-                }
-            }
-        }
-    } else {
-        // Single browser config (not in browsers array)
-        if (session.url) {
-            session.url = expandUrlShortcuts(session.url);
-        }
-        if (session.controlUrl) {
-            session.controlUrl = expandUrlShortcuts(session.controlUrl);
-        }
-        if (session.tracks) {
-            for (let track of session.tracks) {
-                if (track.url) {
-                    track.url = expandUrlShortcuts(track.url);
-                }
-            }
-        }
-    }
-
-    if (session.hasOwnProperty("selectedGene")) {
-        registryForContainer(container).selectedGene = session.selectedGene;
-    }
-    if (session.hasOwnProperty("caption")) {
-        const captionText = session.caption;
-        var captionDiv = document.getElementById("hic-caption");
+    if (Object.hasOwn(session, "caption")) {
+        const captionDiv = document.getElementById("hic-caption");
         if (captionDiv) {
-            captionDiv.textContent = captionText;
+            captionDiv.textContent = session.caption;
         }
     }
 
-    await createBrowserList(container, session);
-
-    if (false !== session.syncDatasets) {
-        registryForContainer(container).sync();
-    }
-
+    await registryForContainer(container).restoreSession(session);
 }
 
 

--- a/js/urlUtils.js
+++ b/js/urlUtils.js
@@ -53,6 +53,31 @@ function expandUrlShortcuts(url) {
     return expandedUrl;
 }
 
+/**
+ * Expand the URL shortcuts everywhere a session document can carry one, in
+ * place.
+ *
+ * Sessions handed straight to `restoreSession` never pass through
+ * `extractConfig`, so a host or a saved file written with `*s3/` would reach the
+ * loaders unexpanded without this. A single-browser config is a session with
+ * its one browser inlined, which is why both shapes are walked.
+ */
+function expandSessionUrlShortcuts(session) {
+
+    for (const config of session.browsers || [session]) {
+        for (const key of ['url', 'controlUrl']) {
+            if (config[key]) {
+                config[key] = expandUrlShortcuts(config[key]);
+            }
+        }
+        for (const track of config.tracks || []) {
+            if (track.url) {
+                track.url = expandUrlShortcuts(track.url);
+            }
+        }
+    }
+}
+
 async function extractConfig(queryString) {
 
     let query = extractQuery(queryString);
@@ -394,4 +419,4 @@ async function expandURL(url) {
 
 }
 
-export {extractConfig, DEFAULT_ANNOTATION_COLOR, expandUrlShortcuts}
+export {extractConfig, DEFAULT_ANNOTATION_COLOR, expandUrlShortcuts, expandSessionUrlShortcuts}

--- a/test/testRegistrySession.js
+++ b/test/testRegistrySession.js
@@ -1,0 +1,384 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import BrowserRegistry, {registryForContainer} from '../js/browserRegistry.js'
+import {toJSON, compressedSession, restoreSession} from '../js/session.js'
+import {init} from '../js/init.js'
+import {withDOM} from './utils/browserFixture.js'
+import DataLoader from '../js/dataLoader.js'
+import State from '../js/hicState.js'
+import ContactMatrixView from '../js/contactMatrixView.js'
+import HICBrowser from '../js/hicBrowser.js'
+import {BGZip} from 'igv-utils'
+
+/**
+ * A session belongs to one embed -- #482, decision 5 of ADR-0004.
+ *
+ * `registry.toJSON()` and `registry.restoreSession(config)` are the real
+ * methods; the exported functions in `js/session.js` delegate. What these tests
+ * assert is *whose* session is being written or replaced, so wherever the claim
+ * is about isolation there are two registries in play. A single-registry
+ * assertion would pass against the page-scoped code these replace.
+ */
+
+/**
+ * A JSDOM around each test in the calling describe, exposing the container the
+ * fixture makes and a way to make more of them. Returns a holder rather than
+ * the elements, which do not exist until `beforeEach` runs.
+ */
+function withContainers() {
+
+    const context = {}
+    let fixture
+
+    beforeEach(() => {
+        fixture = withDOM()
+        context.window = fixture.window
+        context.container = fixture.container
+        context.another = () => {
+            const element = fixture.window.document.createElement('div')
+            fixture.window.document.body.appendChild(element)
+            return element
+        }
+    })
+
+    afterEach(() => {
+        fixture.restore()
+    })
+
+    return context
+}
+
+/**
+ * Carries only what the registry and the session path read off a browser.
+ *
+ * Its root element is real and lives in the registry's container, because the
+ * claim under test is that restoring one embed leaves another embed's *DOM*
+ * standing -- which only a real element can answer.
+ */
+function fakeBrowser(name, registry) {
+    const rootElement = registry.container
+        ? registry.container.ownerDocument.createElement('div')
+        : {classList: {add: () => undefined, remove: () => undefined}, remove: () => undefined}
+    registry.container?.appendChild(rootElement)
+    return {
+        name,
+        registry,
+        rootElement,
+        browserPanelDeleteButton: {style: {display: 'none'}},
+        synchedBrowsers: new Set(),
+        unsyncSelf: () => undefined,
+        toJSON: () => ({name})
+    }
+}
+
+/**
+ * Stand the restore path up without the two things a test cannot supply: the
+ * network reads (`.hic` file, tracks) and the canvas.
+ *
+ * The `.hic` read is the real system boundary here, and the only reason a
+ * restore cannot otherwise be driven in a test. What stands in for it does
+ * exactly what the real loader does with the parts of a config a session round
+ * trip is about: name the dataset, and build the state from `config.state`
+ * through the real `State.fromJSON`. Everything downstream -- the registry, the
+ * browser's own `toJSON`, the state itself -- is the real thing.
+ *
+ * The two update paths are stubbed for the same reason `browserFixture` stubs
+ * the 2D context: what a session carries is state, and every route out of a
+ * repaint ends at either the network or a pixel. Rendering has its own tests.
+ */
+function withStubbedLoads() {
+
+    beforeEach(() => {
+        vi.spyOn(ContactMatrixView.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(HICBrowser.prototype, 'update').mockImplementation(async () => undefined)
+        vi.spyOn(DataLoader.prototype, 'loadHicFile').mockImplementation(async function (config) {
+            this.browser.dataset = {
+                url: config.url,
+                name: config.name,
+                hicFile: {config: {nvi: config.nvi}}
+            }
+            this.browser.state = config.state ? State.fromJSON(config.state) : State.default(config)
+        })
+        vi.spyOn(DataLoader.prototype, 'loadTracks').mockImplementation(async () => undefined)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+}
+
+describe('registry.toJSON', () => {
+
+    const dom = withContainers()
+
+    it('serializes this registry\'s browsers, not another registry\'s', () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        mine.register(fakeBrowser('a', mine))
+        theirs.register(fakeBrowser('b', theirs))
+
+        expect(mine.toJSON().browsers).toEqual([{name: 'a'}])
+        expect(theirs.toJSON().browsers).toEqual([{name: 'b'}])
+    })
+
+    it('serializes this registry\'s selected gene, not another registry\'s', () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        mine.selectedGene = 'ace'
+        theirs.selectedGene = 'egfr'
+
+        expect(mine.toJSON().selectedGene).toBe('ace')
+        expect(theirs.toJSON().selectedGene).toBe('egfr')
+    })
+
+    it('leaves selectedGene out entirely when the embed has none', () => {
+        expect(Object.hasOwn(registryForContainer(dom.container).toJSON(), 'selectedGene')).toBe(false)
+    })
+
+    it('writes an empty browser list for an empty registry', () => {
+        expect(new BrowserRegistry().toJSON().browsers).toEqual([])
+    })
+})
+
+describe('exported toJSON', () => {
+
+    const dom = withContainers()
+
+    it('serializes the registry owning the current browser', () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        for (const [registry, name] of [[mine, 'a'], [theirs, 'b']]) {
+            registry.register(fakeBrowser(name, registry))
+        }
+
+        theirs.select(theirs.browsers[0])
+        expect(toJSON().browsers).toEqual([{name: 'b'}])
+
+        mine.select(mine.browsers[0])
+        expect(toJSON().browsers).toEqual([{name: 'a'}])
+    })
+
+    it('still carries the page caption, which no registry owns', () => {
+        const caption = dom.window.document.createElement('div')
+        caption.id = 'hic-caption'
+        caption.textContent = '  a figure legend  '
+        dom.window.document.body.appendChild(caption)
+
+        const registry = registryForContainer(dom.container)
+        registry.add(fakeBrowser('a', registry))
+
+        expect(toJSON().caption).toBe('a figure legend')
+    })
+
+    it('compresses the same document it returns', () => {
+        const registry = registryForContainer(dom.container)
+        registry.add(fakeBrowser('a', registry))
+        registry.selectedGene = 'ace'
+
+        const compressed = compressedSession()
+
+        expect(compressed.startsWith('session=blob:')).toBe(true)
+        expect(JSON.parse(BGZip.uncompressString(compressed.slice('session=blob:'.length))))
+            .toEqual({browsers: [{name: 'a'}], selectedGene: 'ace'})
+    })
+})
+
+describe('registry.restoreSession', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    it('replaces this registry\'s browsers and takes their DOM down with them', async () => {
+        const registry = registryForContainer(dom.container)
+        const outgoing = fakeBrowser('a', registry)
+        registry.add(outgoing)
+
+        await registry.restoreSession({browsers: []})
+
+        expect(registry.browsers).toEqual([])
+        expect(outgoing.rootElement.isConnected).toBe(false)
+    })
+
+    it('leaves another embed\'s browsers and DOM standing', async () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        const survivor = fakeBrowser('b', theirs)
+        theirs.add(survivor)
+        mine.add(fakeBrowser('a', mine))
+
+        await mine.restoreSession({browsers: []})
+
+        expect(theirs.browsers).toEqual([survivor])
+        expect(theirs.currentBrowser).toBe(survivor)
+        expect(survivor.rootElement.isConnected).toBe(true)
+    })
+
+    it('restores the selected gene onto itself and nobody else', async () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+
+        await mine.restoreSession({browsers: [], selectedGene: 'ace'})
+
+        expect(mine.selectedGene).toBe('ace')
+        expect(theirs.selectedGene).toBeUndefined()
+    })
+
+    it('leaves a previously selected gene alone when the session names none', async () => {
+        const registry = registryForContainer(dom.container)
+        registry.selectedGene = 'ace'
+
+        await registry.restoreSession({browsers: []})
+
+        expect(registry.selectedGene).toBe('ace')
+    })
+
+    it('expands URL shortcuts in the configs it is handed', async () => {
+        const registry = registryForContainer(dom.container)
+        const session = {
+            browsers: [{
+                url: '*s3/hiseq/gm12878/in-situ/combined.hic',
+                tracks: [{url: '*s3/hiseq/gm12878/in-situ/combined_peaks.txt'}]
+            }]
+        }
+
+        await registry.restoreSession(session)
+
+        expect(session.browsers[0].url).toBe('https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/combined.hic')
+        expect(session.browsers[0].tracks[0].url)
+            .toBe('https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/combined_peaks.txt')
+    })
+})
+
+describe('exported restoreSession', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    it('restores into the registry owning the container it is given', async () => {
+        const mine = registryForContainer(dom.container)
+        const theirs = registryForContainer(dom.another())
+        const survivor = fakeBrowser('b', theirs)
+        theirs.add(survivor)
+
+        await restoreSession(dom.container, {browsers: [{url: 'https://example.com/a.hic'}]})
+
+        expect(mine.browsers).toHaveLength(1)
+        expect(theirs.browsers).toEqual([survivor])
+        expect(survivor.rootElement.isConnected).toBe(true)
+    })
+
+    it('restores the page caption, which no registry owns', async () => {
+        const caption = dom.window.document.createElement('div')
+        caption.id = 'hic-caption'
+        dom.window.document.body.appendChild(caption)
+
+        await restoreSession(dom.container, {browsers: [], caption: 'a figure legend'})
+
+        expect(caption.textContent).toBe('a figure legend')
+    })
+
+    it('returns a promise that settles once the browsers are built', async () => {
+        const registry = registryForContainer(dom.container)
+
+        await restoreSession(dom.container, {browsers: [{url: 'https://example.com/a.hic'}]})
+
+        expect(registry.browsers).toHaveLength(1)
+        expect(registry.currentBrowser).toBe(registry.browsers[0])
+    })
+})
+
+describe('session round trip', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    /**
+     * A session written by hand, not by the code under test. The canonical
+     * state below is the independent source of truth the round trip is checked
+     * against -- reading it back off the browser that produced it would make
+     * the assertion true by construction.
+     */
+    const saved = {
+        browsers: [{
+            url: 'https://example.com/a.hic',
+            state: {chr1: 17, chr2: 17, zoom: 8, x: 12025, y: 12025, pixelSize: 1, normalization: 'NONE'}
+        }],
+        selectedGene: 'ace'
+    }
+
+    it('restores the canonical state it saved, into another embed', async () => {
+        const first = registryForContainer(dom.container)
+        await first.restoreSession(structuredClone(saved))
+
+        const second = registryForContainer(dom.another())
+        await second.restoreSession(first.toJSON())
+
+        expect(second.browsers[0].state.toJSON()).toEqual(saved.browsers[0].state)
+        expect(second.selectedGene).toBe('ace')
+    })
+
+    it('restores the same canonical state a second time round', async () => {
+        // A session that survives one trip can still be lossy in a way the
+        // first pass hides -- a field defaulted on read and dropped on write
+        // looks right until it is written again.
+        const registry = registryForContainer(dom.container)
+
+        await registry.restoreSession(structuredClone(saved))
+        await registry.restoreSession(registry.toJSON())
+        await registry.restoreSession(registry.toJSON())
+
+        expect(registry.browsers[0].state.toJSON()).toEqual(saved.browsers[0].state)
+    })
+
+    it('survives the compressed URL form', async () => {
+        const first = registryForContainer(dom.container)
+        await first.restoreSession(structuredClone(saved))
+        first.select(first.browsers[0])
+
+        const blob = compressedSession().slice('session=blob:'.length)
+
+        const second = registryForContainer(dom.another())
+        await second.restoreSession(JSON.parse(BGZip.uncompressString(blob)))
+
+        expect(second.browsers[0].state.toJSON()).toEqual(saved.browsers[0].state)
+        expect(second.browsers[0].dataset.url).toBe('https://example.com/a.hic')
+    })
+})
+
+describe('init on a second container', () => {
+
+    const dom = withContainers()
+    withStubbedLoads()
+
+    const config = url => ({url, queryParametersSupported: false})
+
+    it('leaves the first embed\'s browsers and DOM standing -- #384', async () => {
+        const first = await init(dom.container, config('https://example.com/a.hic'))
+        const firstRoot = first.rootElement
+
+        const second = await init(dom.another(), config('https://example.com/b.hic'))
+
+        expect(first.dataset.url).toBe('https://example.com/a.hic')
+        expect(second.dataset.url).toBe('https://example.com/b.hic')
+        expect(firstRoot.isConnected).toBe(true)
+        expect(registryForContainer(dom.container).browsers).toEqual([first])
+    })
+
+    it('replaces the contents of a container initialized twice', async () => {
+        const outgoing = await init(dom.container, config('https://example.com/a.hic'))
+        const outgoingRoot = outgoing.rootElement
+
+        const incoming = await init(dom.container, config('https://example.com/b.hic'))
+
+        expect(registryForContainer(dom.container).browsers).toEqual([incoming])
+        expect(outgoingRoot.isConnected).toBe(false)
+    })
+
+    it('gives each embed its own selected gene across a restore', async () => {
+        await init(dom.container, {...config('https://example.com/a.hic'), selectedGene: 'ace'})
+        const other = dom.another()
+        await init(other, {...config('https://example.com/b.hic'), selectedGene: 'egfr'})
+
+        expect(registryForContainer(dom.container).selectedGene).toBe('ace')
+        expect(registryForContainer(other).selectedGene).toBe('egfr')
+    })
+})


### PR DESCRIPTION
Closes #482. Decision 5 of [ADR-0004](../blob/master/docs/adr/0004-browser-registry-per-container.md); the load-bearing half of #384.

## What changed

A saved session describes **one embed**, not the page.

- `registry.toJSON()` serializes that registry's browsers and selected gene.
- `registry.restoreSession(config)` replaces that registry's browsers.
- The three exported functions — `toJSON`, `restoreSession(container, config)`, `compressedSession` — keep their signatures and return shapes and delegate. Both known consumers call all three (ADR-0003), so nothing moves under them.
- The URL-shortcut expansion the old `restoreSession` inlined twice is now `expandSessionUrlShortcuts(session)` in `js/urlUtils.js`.
- `js/session.js` goes from 108 lines to 75.

The **caption** stays in `js/session.js` deliberately: it is a single `#hic-caption` element outside every container that two embeds share, and no registry can own it. `CONTEXT.md` now says so.

## Two things to flag

1. **The registry now imports `createBrowserList`, which is a cycle** (`browserRegistry` → `createBrowser` → `hicBrowser` → `browserRegistry`). It is inert — nothing runs at module-evaluation time — and Rollup emits no warning, but it is real. The alternative, letting the registry construct an `HICBrowser` itself, breaks the rule that makes it constructible in a test. Commented at the import.
2. **`deleteAllBrowsers` in `js/createBrowser.js` now has no callers.** `session.js` was the last one. It is absent from `js/publicApi.js` and from the `js/index.js` exports, but per CONTEXT.md's rule on lifecycle-shaped names it is left alone rather than deleted here.

## Tests

`test/testRegistrySession.js`, 21 tests, built test-first at three seams:

- **`registry.toJSON`** — serializes its own browsers and gene, with two registries in play.
- **exported `toJSON`** — follows the page-wide selection, still carries the caption; `compressedSession` compresses the same document.
- **`registry.restoreSession`** — replaces its own browsers and DOM, leaves another embed's standing, restores the gene onto itself, expands shortcuts.
- **exported `restoreSession`** — delegates to the container's registry, restores the page caption.
- **round trip** — save → restore into a second embed, canonical state compared against a hand-written literal; also three passes, and the compressed-URL form.
- **`init()` on two containers** — #384 at the outermost seam: two embeds coexist; a second `init()` on the same container replaces its contents.

The `.hic` read is stubbed — the one system boundary on the restore path, and the only reason a restore cannot otherwise be driven in a test. State is built through the real `State.fromJSON`, and the registry, the browser's `toJSON` and the state itself are the real thing.

Full suite 414/414 green. `npm run build` clean.

## Acceptance criteria

- [x] `registry.toJSON()` serializes only that registry's browsers and selected gene
- [x] `registry.restoreSession(config)` replaces only that registry's browsers
- [x] Restoring a session into one container leaves other containers' browsers and DOM untouched
- [x] Exported `toJSON`, `restoreSession` and `compressedSession` keep their signatures and return shapes
- [x] A round-trip test passes
- [x] Existing session tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)